### PR TITLE
fix testing with maturin

### DIFF
--- a/.test.sh
+++ b/.test.sh
@@ -12,10 +12,17 @@ chmod +x /tmp/rustup-init
 
 /tmp/rustup-init -y
 
-export PATH=$PATH:~/.cargo/bin
+export PATH=$PATH:~/.cargo/bin:~/.local/bin
+
+# need a virtualenv or else maturin won't run
+# use site packages so we don't have to reinstall
+# pytorch & friends
+python3 -m venv --system-site-packages .
+
+
+source bin/activate
 
 # run setup
-
 make setup
 
 # okay, we've got an install.


### PR DESCRIPTION
Maturin doesn't run unless it's in a virtualenv and previously it was not placed on the PATH in the testing script.

This PR changes the testing script so that Maturin runs.

Run of tests for this PR will be available soon [here]( https://proverbot.web.illinois.edu/tom-eb7e294d.txt), once the testing run finishes.