### PR TITLE
Model Performance Improvements

### DIFF
--- a/src/models/components.py
+++ b/src/models/components.py
@@ -70,7 +70,6 @@ class SimpleEmbedding(Embedding):
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from torch.autograd import Variable
 from util import maybe_cuda, eprint, timeSince, FloatTensor
 from typing import TypeVar, Generic, Iterable, Tuple
 import argparse
@@ -128,17 +127,15 @@ class DNNClassifier(nn.Module):
         super(DNNClassifier, self).__init__()
         self.num_layers = num_layers
         self.in_layer = maybe_cuda(nn.Linear(input_vocab_size, hidden_size))
-        for i in range(num_layers - 1):
-            self.add_module("_layer{}".format(i),
-                            maybe_cuda(nn.Linear(hidden_size, hidden_size)))
+        self.layers = nn.ModuleList([maybe_cuda(nn.Linear(hidden_size,hidden_size)) for _ in range(num_layers-1)])
         self.out_layer = maybe_cuda(nn.Linear(hidden_size, output_vocab_size))
         self.softmax = maybe_cuda(nn.LogSoftmax(dim=1))
 
     def forward(self, input : torch.FloatTensor) -> torch.FloatTensor:
-        layer_values = self.in_layer(maybe_cuda(Variable(input)))
-        for i in range(self.num_layers - 1):
+        layer_values = self.in_layer(maybe_cuda(input))
+        for layer in self.layers:
             layer_values = F.relu(layer_values)
-            layer_values = getattr(self, "_layer{}".format(i))(layer_values)
+            layer_values = layer(layer_values)
         layer_values = F.relu(layer_values)
         return self.softmax(self.out_layer(layer_values)).view(input.size()[0], -1)
 
@@ -151,9 +148,8 @@ class DNNScorer(nn.Module):
         if self.num_layers > 1:
             self.in_layer = maybe_cuda(nn.Linear(input_vocab_size,
                                                  hidden_size))
-        for i in range(num_layers - 2):
-            self.add_module("_layer{}".format(i),
-                            maybe_cuda(nn.Linear(hidden_size, hidden_size)))
+
+        self.layers = nn.ModuleList([maybe_cuda(nn.Linear(hidden_size,hidden_size)) for _ in range(num_layers-2)])
         if self.num_layers > 1:
             self.out_layer = maybe_cuda(nn.Linear(hidden_size, 1))
         else:
@@ -161,12 +157,12 @@ class DNNScorer(nn.Module):
 
     def forward(self, input: torch.FloatTensor) -> torch.FloatTensor:
         if self.num_layers > 1:
-            layer_values = self.in_layer(maybe_cuda(Variable(input)))
+            layer_values = self.in_layer(maybe_cuda(input))
         else:
             layer_values = input
-        for i in range(self.num_layers - 2):
+        for layer in self.layers:
             layer_values = F.relu(layer_values)
-            layer_values = getattr(self, "_layer{}".format(i))(layer_values)
+            layer_values = layer(layer_values)
         layer_values = F.relu(layer_values)
         return self.out_layer(layer_values)
 
@@ -205,30 +201,26 @@ class WordFeaturesEncoder(nn.Module):
         self.num_layers = num_layers
         self.hidden_size = hidden_size
         self.num_word_features = len(input_vocab_sizes)
-        for i, vocab_size in enumerate(input_vocab_sizes):
-            self.add_module("_word_embedding{}".format(i),
-                            maybe_cuda(nn.Embedding(vocab_size, hidden_size)))
+        self.word_embeddings = nn.ModuleList([maybe_cuda(nn.Embedding(vocab_size,hidden_size)) for vocab_size in input_vocab_sizes])
         self._in_layer = maybe_cuda(nn.Linear(hidden_size * len(input_vocab_sizes),
                                               hidden_size))
-        for i in range(num_layers - 1):
-            self.add_module("_layer{}".format(i),
-                            maybe_cuda(nn.Linear(hidden_size, hidden_size)))
+        self.layers = nn.ModuleList([maybe_cuda(nn.Linear(hidden_size,hidden_size)) for _ in range(num_layers-1)])
         self._out_layer = maybe_cuda(nn.Linear(hidden_size, output_vocab_size))
 
     def forward(self, input_vec : torch.LongTensor) -> torch.FloatTensor:
         batch_size = input_vec.size()[0]
         word_embedded_features = []
-        for i in range(self.num_word_features):
-            word_feature_var = maybe_cuda(Variable(input_vec[:,i]))
-            embedded = getattr(self, "_word_embedding{}".format(i))(word_feature_var)\
+        for i,word_embedding in enumerate(self.word_embeddings):
+            word_feature_var = maybe_cuda(input_vec[:,i])
+            embedded = word_embedding(word_feature_var)\
                 .view(batch_size, self.hidden_size)
             word_embedded_features.append(embedded)
         word_embedded_features_vec = \
             torch.cat(word_embedded_features, dim=1)
         vals = self._in_layer(word_embedded_features_vec)
-        for i in range(self.num_layers - 1):
+        for layer in self.layers:
             vals = F.relu(vals)
-            vals = getattr(self, "_layer{}".format(i))(vals)
+            vals = layer(vals)
         vals = F.relu(vals)
         result = self._out_layer(vals).view(batch_size, -1)
         return result
@@ -397,7 +389,7 @@ class DNNClassifierModel(StraightlineClassifierModel[NeuralPredictorState]):
                 input_batch, output_batch = data_batch
                 # with autograd.detect_anomaly():
                 predictionDistribution = self._model(input_batch)
-                output_var = maybe_cuda(Variable(output_batch))
+                output_var = maybe_cuda(output_batch)
                 loss = self._criterion(predictionDistribution, output_var)
                 loss.backward()
                 self._optimizer.step()

--- a/src/models/features_polyarg_predictor.py
+++ b/src/models/features_polyarg_predictor.py
@@ -23,7 +23,6 @@ from tqdm import tqdm
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from torch.autograd import Variable
 from torch.nn.utils.rnn import pad_sequence
 
 from features import (WordFeature, VecFeature, Feature,
@@ -118,11 +117,13 @@ class GoalTokenEncoderModel(nn.Module):
         self._token_embedding = maybe_cuda(
             nn.Embedding(input_vocab_size, hidden_size))
         self._gru = maybe_cuda(nn.GRU(hidden_size, hidden_size))
+        # localize global variable for compilation
+        self._EOS_token = EOS_token
 
     def forward(self, stem_batch: torch.LongTensor, goal_batch: torch.LongTensor) \
             -> torch.FloatTensor:
-        goal_var = maybe_cuda(Variable(goal_batch))
-        stem_var = maybe_cuda(Variable(stem_batch))
+        goal_var = maybe_cuda(goal_batch)
+        stem_var = maybe_cuda(stem_batch)
         batch_size = goal_batch.size()[0]
         assert stem_batch.size()[0] == batch_size
         initial_hidden = self._stem_embedding(stem_var)\
@@ -135,7 +136,7 @@ class GoalTokenEncoderModel(nn.Module):
             token_batch2 = F.relu(token_batch)
             token_out, hidden = self._gru(token_batch2, hidden)
             encoded_tokens.append(token_out.squeeze(dim=0).unsqueeze(1))
-        end_token_embedded = self._token_embedding(LongTensor([EOS_token])
+        end_token_embedded = self._token_embedding(LongTensor([self._EOS_token])
                                                    .expand(batch_size))\
             .view(1, batch_size, self.hidden_size)
         final_out, _final_hidden = self._gru(F.relu(end_token_embedded), hidden)
@@ -184,8 +185,8 @@ class HypArgEncoder(nn.Module):
                 stems_batch: torch.LongTensor,
                 goals_encoded_batch: torch.FloatTensor,
                 hyps_batch: torch.LongTensor) -> torch.FloatTensor:
-        stems_var = maybe_cuda(Variable(stems_batch))
-        hyps_var = maybe_cuda(Variable(hyps_batch))
+        stems_var = maybe_cuda(stems_batch)
+        hyps_var = maybe_cuda(hyps_batch)
         batch_size = stems_batch.size()[0]
         assert goals_encoded_batch.size()[0] == batch_size
         assert hyps_batch.size()[0] == batch_size, \
@@ -228,7 +229,7 @@ class HypArgModel(nn.Module):
         encoded = self.arg_encoder(stems_batch, goals_encoded_batch,
                                    hyps_batch)
         hyp_likelyhoods = self._likelyhood_decoder(
-            torch.cat((encoded, Variable(hypfeatures_batch)), dim=1))
+            torch.cat((encoded, hypfeatures_batch), dim=1))
         return hyp_likelyhoods
 
 
@@ -268,7 +269,7 @@ class FeaturesPolyArgModel(nn.Module):
                  hyp_model: HypArgModel) -> None:
         super().__init__()
         self.stem_classifier = maybe_cuda(stem_classifier)
-        self.goal_args_model = maybe_cuda(goal_args_model)
+        self.goal_args_model = torch.jit.script(maybe_cuda(goal_args_model))
         self.goal_encoder = maybe_cuda(goal_encoder)
         self.hyp_model = maybe_cuda(hyp_model)
 
@@ -893,7 +894,7 @@ class FeaturesPolyargPredictor(
         stemDistributions, predictedProbs, predictedStemIdxs = \
           self.predict_stems(model, stem_width, word_features_batch,
                              vec_features_batch)
-        stem_var = maybe_cuda(Variable(stem_idxs_batch))
+        stem_var = maybe_cuda(stem_idxs_batch)
         mergedStemIdxs = []
         for stem_idx, predictedStemIdxList in zip(stem_idxs_batch, predictedStemIdxs):
             if stem_idx.item() in predictedStemIdxList:
@@ -907,17 +908,15 @@ class FeaturesPolyargPredictor(
                                                   idxList, stem_idx
                                                   in zip(mergedStemIdxs, stem_var)])
         if arg_values.hyp_rnn:
-            tokenized_hyps_var = maybe_cuda(
-                Variable(tokenized_hyp_types_batch))
+            tokenized_hyps_var = maybe_cuda(tokenized_hyp_types_batch)
         else:
             tokenized_hyps_var = maybe_cuda(
-                Variable(torch.zeros_like(tokenized_hyp_types_batch)))
+                torch.zeros_like(tokenized_hyp_types_batch))
 
         if arg_values.hyp_features:
-            hyp_features_var = maybe_cuda(Variable(hyp_features_batch))
+            hyp_features_var = maybe_cuda(hyp_features_batch)
         else:
-            hyp_features_var = maybe_cuda(
-                Variable(torch.zeros_like(hyp_features_batch)))
+            hyp_features_var = maybe_cuda(torch.zeros_like(hyp_features_batch))
 
         goal_arg_values = self.goal_token_scores(model, arg_values,
                                                  mergedStemIdxsT, tokenized_goals_batch,
@@ -966,8 +965,8 @@ class FeaturesPolyargPredictor(
                               .expand(-1, -1, num_probs)
                               .contiguous()
                               .view(batch_size, stem_width * num_probs))
-        total_arg_var = maybe_cuda(Variable(arg_total_idxs_batch +
-                                            (correctPredictionIdxs * num_probs)))\
+        total_arg_var = maybe_cuda(arg_total_idxs_batch +
+                                            (correctPredictionIdxs * num_probs))\
             .view(batch_size)
         loss = FloatTensor([0.])
         loss += self._criterion(stemDistributions, stem_var)

--- a/src/util.py
+++ b/src/util.py
@@ -40,31 +40,6 @@ from sexpdata import Symbol
 from dataloader import rust_parse_sexp_one_level
 from pathlib import Path
 
-
-def maybe_cuda(component):
-    if use_cuda:
-        return component.to(device=torch.device(cuda_device))
-    else:
-        return component
-
-def LongTensor(*args : Any) -> torch.LongTensor:
-    if use_cuda:
-        return torch.cuda.LongTensor(*args)
-    else:
-        return torch.LongTensor(*args)
-
-def FloatTensor(*args : Any) -> torch.FloatTensor:
-    if use_cuda:
-        return torch.cuda.FloatTensor(*args)
-    else:
-        return torch.FloatTensor(*args)
-
-def ByteTensor(*args : Any) -> torch.ByteTensor:
-    if use_cuda:
-        return torch.cuda.ByteTensor(*args)
-    else:
-        return torch.ByteTensor(*args)
-
 def asMinutes(s : float) -> str:
     m = math.floor(s / 60)
     s -= m * 60
@@ -224,7 +199,38 @@ def silent():
 with silent():
     use_cuda = torch.cuda.is_available()
     cuda_device = "cuda:0"
-    # assert use_cuda
+    
+    # we want to use this in modules,
+    # but we also want to compile those modules.
+
+    # pytorch is extremely unhappy with references to
+    # global variables.
+
+    # therefore, we will bake the above static result
+    # into these functions right now.
+
+    if use_cuda:
+        def maybe_cuda(component):
+                return component.to(device=torch.device(cuda_device))
+
+        LongTensor = torch.cuda.Longtensor
+
+        FloatTensor = torch.cuda.FloatTensor
+
+        ByteTensor = torch.cuda.ByteTensor
+    else:
+        def maybe_cuda(component):
+                return component
+
+        LongTensor = torch.LongTensor
+
+        FloatTensor = torch.FloatTensor
+
+        ByteTensor = torch.ByteTensor
+
+    # now these can be easily compiled into torchscript.
+
+
 
 import signal as sig
 @contextlib.contextmanager

--- a/src/util.py
+++ b/src/util.py
@@ -211,23 +211,28 @@ with silent():
 
     if use_cuda:
         def maybe_cuda(component):
-                return component.to(device=torch.device(cuda_device))
+            return component.to(device=torch.device("cuda:0"))
 
-        LongTensor = torch.cuda.Longtensor
+        def LongTensor(x : List[int]):
+            return torch.tensor(x,dtype=torch.long).to(device=torch.device("cuda:0"))
 
-        FloatTensor = torch.cuda.FloatTensor
+        def FloatTensor(x : List[float]):
+            return torch.tensor(x,dtype=torch.float32).to(device=torch.device("cuda:0"))
 
-        ByteTensor = torch.cuda.ByteTensor
+        def ByteTensor(x : List[int]):
+            return torch.tensor(x,dtype=torch.uint8).to(device=torch.device("cuda:0"))
     else:
         def maybe_cuda(component):
                 return component
+ 
+        def LongTensor(x : List[int]):
+            return torch.tensor(x,dtype=torch.long)
 
-        LongTensor = torch.LongTensor
+        def FloatTensor(x : List[float]):
+            return torch.tensor(x,dtype=torch.float32)
 
-        FloatTensor = torch.FloatTensor
-
-        ByteTensor = torch.ByteTensor
-
+        def ByteTensor(x : List[int]):
+            return torch.tensor(x,dtype=torch.uint8)
     # now these can be easily compiled into torchscript.
 
 


### PR DESCRIPTION
This PR dramatically improves the speed of the model by:

1. Jitting the model (slight performance increase).
2. Manually fusing operations that were previously done in a for loop (major performance increase).

There are likely more opportunities to improve the model's speed in features_polyargs_predictor, but since these changes suffice for approximately a ~4x decrease in training time I opted to submit these first.

I will comment links to the most recent test logs for the current develop branch and this test branch once they finish.