### PR TITLE
Add support for opam switches to workers.

### DIFF
--- a/src/search_file.py
+++ b/src/search_file.py
@@ -239,7 +239,7 @@ def search_file_worker(args: argparse.Namespace,
     else:
         switch_dict = None
 
-    with Worker(args, worker_idx, predictor) as worker:
+    with Worker(args, worker_idx, predictor, switch_dict) as worker:
         while True:
             try:
                 next_job = jobs.get_nowait()

--- a/src/search_strategies.py
+++ b/src/search_strategies.py
@@ -179,6 +179,7 @@ class SearchGraph:
             node_handle.attr["style"] = "filled"
 
     def draw(self, filename: str) -> None:
+        Path(filename).parent.mkdir(parents=True, exist_ok=True)
         with nostderr():
             self.__graph.draw(filename, prog="dot")
 

--- a/src/util.py
+++ b/src/util.py
@@ -197,16 +197,20 @@ class DummyFile:
 
 @contextlib.contextmanager
 def nostdout():
-    save_stdout = sys.stdout
-    sys.stdout = DummyFile()
-    yield
-    sys.stdout = save_stdout
+    try:
+        save_stdout = sys.stdout
+        sys.stdout = DummyFile()
+        yield
+    finally:
+        sys.stdout = save_stdout
 @contextlib.contextmanager
 def nostderr():
-    save_stderr = sys.stderr
-    sys.stderr = DummyFile()
-    yield
-    sys.stderr = save_stderr
+    try:
+        save_stderr = sys.stderr
+        sys.stderr = DummyFile()
+        yield
+    finally:
+        sys.stderr = save_stderr
 
 @contextlib.contextmanager
 def silent():


### PR DESCRIPTION
(1) `search_file.py` computes a `switch_dict` based on the JSON split file. The point of the switch dict is to run different projects with different Coq versions. In this commit the switch dict is passed to each worker.  It was missing before.

(2) Suppose a JSON split file flag (e.g. `--split-file=coqgym_projs_splits.json` ) is used with the `search_report` switch. If subfolders for each project are not created in the output report directory, the SVG-creation command in `src/search_strategies.py` fails. It is wrapped in a `util.nostderr()` context manager.  `nostderr()` does not have a `try/finally` block. Before this commit, `nostderr()` would disable `stderr`, and the error from `pygraphviz` would be printed to a dummy file. This silently brings down all workers in the worker pool, and it looks like proverbot is stuck.

This commit makes sure the parent directory is created before trying to generate the SVG and splits `nostderr()` into a `try` and `finally` part.

TESTED =
(1) Did query the coq_minor_version() of the worker.coq SerapiInstance before and after the change.
(2) Did run `search_report` with and without a project subfolder in the output-dir before and after.