### PR TITLE
Rl faster traversal

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ pathlib_revised
 sparse_list
 tensorboard
 maturin
+numba

--- a/src/linearize_semicolons.py
+++ b/src/linearize_semicolons.py
@@ -608,7 +608,7 @@ def get_linearized(args: argparse.Namespace, coqargs: List[str],
 def try_load_lin(args: argparse.Namespace, file_idx: int, filename: str) \
         -> Optional[List[str]]:
     lin_path = Path(filename + ".lin")
-    if args.verbose:
+    if args.verbose > 0:
         eprint("Attempting to load cached linearized version from {}"
                .format(lin_path))
     if not lin_path.exists():

--- a/src/models/components.py
+++ b/src/models/components.py
@@ -70,7 +70,8 @@ class SimpleEmbedding(Embedding):
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from util import maybe_cuda, eprint, timeSince, FloatTensor
+from util import eprint, timeSince
+from torch_util import maybe_cuda, FloatTensor
 from typing import TypeVar, Generic, Iterable, Tuple
 import argparse
 

--- a/src/models/features_polyarg_predictor.py
+++ b/src/models/features_polyarg_predictor.py
@@ -31,8 +31,8 @@ from features import (WordFeature, VecFeature, Feature,
 from tokenizer import Tokenizer
 from data import (ListDataset, RawDataset,
                   EOS_token)
-from util import (eprint, maybe_cuda, LongTensor, FloatTensor,
-                  ByteTensor, print_time, unwrap)
+from util import (eprint, print_time, unwrap)
+from torch_util import (maybe_cuda, LongTensor, FloatTensor, ByteTensor)
 import util
 import math
 from coq_serapy.contexts import TacticContext

--- a/src/models/tactic_predictor.py
+++ b/src/models/tactic_predictor.py
@@ -227,7 +227,8 @@ from torch import optim
 import torch.nn as nn
 import numpy as np
 from util import *
-from util import chunks, maybe_cuda
+from util import chunks
+from torch_util import maybe_cuda
 
 optimizers = {
     "SGD": optim.SGD,

--- a/src/predict_tactic.py
+++ b/src/predict_tactic.py
@@ -26,96 +26,74 @@ import functools
 from models.tactic_predictor import TacticPredictor, TrainablePredictor
 from models.components import DNNClassifierModel
 
-from models import encdecrnn_predictor
-from models import try_common_predictor
-from models import wordbagclass_predictor
-from models import ngramclass_predictor
-from models import encclass_predictor
-from models import dnnclass_predictor
-from models import k_nearest_predictor
-from models import autoclass_predictor
-# from models import wordbagsvm_classifier
-# from models import ngramsvm_classifier
-from models import pec_predictor
-from models import features_predictor
-from models import encfeatures_predictor
-# from models import featuressvm_predictor
-from models import apply_predictor
-from models import apply_baselines
-# from models import hypstem_predictor
-from models import hypfeatures_predictor
-from models import copyarg_predictor
-from models import numeric_induction
-from models import features_polyarg_predictor
-from models import reinforced_features_polyarg
+import importlib
 
 loadable_predictors = {
-    'encdec' : encdecrnn_predictor.EncDecRNNPredictor,
-    'encclass' : encclass_predictor.EncClassPredictor,
-    'dnnclass' : dnnclass_predictor.DNNClassPredictor,
-    'trycommon' : try_common_predictor.TryCommonPredictor,
-    'wordbagclass' : wordbagclass_predictor.WordBagClassifyPredictor,
-    'ngramclass' : ngramclass_predictor.NGramClassifyPredictor,
-    'k-nearest' : k_nearest_predictor.KNNPredictor,
-    'autoclass' : autoclass_predictor.AutoClassPredictor,
-    # 'wordbagsvm' : wordbagsvm_classifier.WordBagSVMClassifier,
-    # 'ngramsvm' : ngramsvm_classifier.NGramSVMClassifier,
-    'pec' : pec_predictor.PECPredictor,
-    'features' : features_predictor.FeaturesPredictor,
-    # 'featuressvm' : featuressvm_predictor.FeaturesSVMPredictor,
-    'encfeatures' : encfeatures_predictor.EncFeaturesPredictor,
-    'apply' : apply_predictor.ApplyPredictor,
-    # "hypstem" : functools.partial(hypstem_predictor.HypStemPredictor,
-    #                               DNNClassifierModel),
-    "hypfeatures" : hypfeatures_predictor.HypFeaturesPredictor,
-    "copyarg" : copyarg_predictor.CopyArgPredictor,
-    "polyarg" : features_polyarg_predictor.FeaturesPolyargPredictor,
-    "refpa": reinforced_features_polyarg.ReinforcedFeaturesPolyargPredictor,
+    'encdec' : ("encdecrnn_predictor", "EncDecRNNPredictor"),
+    'encclass' : ("encclass_predictor", "EncClassPredictor"),
+    'dnnclass' : ("dnnclass_predictor", "DNNClassPredictor"),
+    'trycommon' : ("try_common_predictor", "TryCommonPredictor"),
+    'wordbagclass' : ("wordbagclass_predictor", "WordBagClassifyPredictor"),
+    'ngramclass' : ("ngramclass_predictor", "NGramClassifyPredictor"),
+    'k-nearest' : ("k_nearest_predictor", "KNNPredictor"),
+    'autoclass' : ("autoclass_predictor", "AutoClassPredictor"),
+    'wordbagsvm' : ("wordbagsvm_classifier", "WordBagSVMClassifier"),
+    'ngramsvm' : ("ngramsvm_classifier", "NGramSVMClassifier"),
+    'pec' : ("pec_predictor", "PECPredictor"),
+    'features' : ("features_predictor", "FeaturesPredictor"),
+    'featuressvm' : ("featuressvm_predictor", "FeaturesSVMPredictor"),
+    'encfeatures' : ("encfeatures_predictor", "EncFeaturesPredictor"),
+    'apply' : ("apply_predictor", "ApplyPredictor"),
+    'hypfeatures' : ("hypfeatures_predictor", "HypFeaturesPredictor"),
+    'copyarg' : ("copyarg_predictor", "CopyArgPredictor"),
+    'polyarg' : ("features_polyarg_predictor", "FeaturesPolyargPredictor"),
+    'refpa': ("reinforced_features_polyarg", "ReinforcedFeaturesPolyargPredictor"),
 }
 
 static_predictors = {
-    'apply_longest' : apply_baselines.ApplyLongestPredictor,
-    'apply_similar' : apply_baselines.ApplyStringSimilarPredictor,
-    'apply_similar2' : apply_baselines.ApplyNormalizedSimilarPredictor,
-    'apply_wordsim' : apply_baselines.ApplyWordSimlarPredictor,
-    'numeric_induction' : numeric_induction.NumericInductionPredictor,
+    'apply_longest' : ("apply_baselines", "ApplyLongestPredictor"),
+    'apply_similar' : ("apply_baselines", "ApplyStringSimilarPredictor"),
+    'apply_similar2' : ("apply_baselines", "ApplyNormalizedSimilarPredictor"),
+    'apply_wordsim' : ("apply_baselines", "ApplyWordSimlarPredictor"),
+    'numeric_induction' : ("numeric_induction", "NumericInductionPredictor"),
 }
 
 trainable_modules : Dict[str, Callable[[List[str]], None]] = {
-    "encdec" : encdecrnn_predictor.main,
-    "encclass" : encclass_predictor.main,
-    "dnnclass" : dnnclass_predictor.main,
-    "trycommon" : try_common_predictor.train,
-    "wordbagclass" : wordbagclass_predictor.main,
-    "ngramclass" : ngramclass_predictor.main,
-    "k-nearest" : k_nearest_predictor.main,
-    "autoclass" : autoclass_predictor.main,
-    # "wordbagsvm" : wordbagsvm_classifier.main,
-    # "ngramsvm" : ngramsvm_classifier.main,
-    "pec" : pec_predictor.main,
-    "features" : features_predictor.main,
-    # "featuressvm" : featuressvm_predictor.main,
-    "encfeatures" : encfeatures_predictor.main,
-    "relevance" : apply_predictor.train_relevance,
-    # "hypstem" : hypstem_predictor.main,
-    "hypfeatures" : hypfeatures_predictor.main,
-    "copyarg" : copyarg_predictor.main,
-    "polyarg" : features_polyarg_predictor.main,
+    "encdec" : ("encdecrnn_predictor", "main"),
+    "encclass" : ("encclass_predictor", "main"),
+    "dnnclass" : ("dnnclass_predictor", "main"),
+    "trycommon" : ("try_common_predictor", "train"),
+    "wordbagclass" : ("wordbagclass_predictor", "main"),
+    "ngramclass" : ("ngramclass_predictor", "main"),
+    "k-nearest" : ("k_nearest_predictor", "main"),
+    "autoclass" : ("autoclass_predictor", "main"),
+    "wordbagsvm" : ("wordbagsvm_classifier", "main"),
+    "ngramsvm" : ("ngramsvm_classifier", "main"),
+    "pec" : ("pec_predictor", "main"),
+    "features" : ("features_predictor", "main"),
+    "featuressvm" : ("featuressvm_predictor", "main"),
+    "encfeatures" : ("encfeatures_predictor", "main"),
+    "relevance" : ("apply_predictor", "train_relevance"),
+    "hypstem" : ("hypstem_predictor", "main"),
+    "hypfeatures" : ("hypfeatures_predictor", "main"),
+    "copyarg" : ("copyarg_predictor", "main"),
+    "polyarg" : ("features_polyarg_predictor", "main"),
 }
 
+def loadTrainablePredictor(predictor_type: str) -> Callable[[List[str]], None]:
+    module_name, method_name = trainable_modules[predictor_type]
+    method = vars(importlib.import_module("models." + module_name))[method_name]
+    return method
+
 def loadPredictorByName(predictor_type : str) -> TacticPredictor:
-    # Silencing the type checker on this line because the "real" type
-    # of the predictors dictionary is "string to classes constructors
-    # that derive from TacticPredictor, but are not tactic
-    # predictor". But I don't know how to specify that.
-    return static_predictors[predictor_type]() # type: ignore
+    module_name, class_name = static_predictors[predictor_type]
+    predictor_class = vars(importlib.import_module("models." + module_name))[class_name]
+    return predictor_class()
 
 def loadPredictorByFile(filename : str) -> TrainablePredictor:
     predictor_type, saved_state = torch.load(str(filename), map_location='cpu')
-    # Silencing the type checker on this line because the "real" type
-    # of the predictors dictionary is "string to classes constructors
-    # that derive from TacticPredictor, but are not tactic
-    # predictor". But I don't know how to specify that.
-    predictor = loadable_predictors[predictor_type]() # type: ignore
+    module_name, class_name = loadable_predictors[predictor_type]
+    predictor_class = vars(importlib.import_module("models." + module_name))[class_name]
+    predictor = predictor_class()
     predictor.load_saved_state(*saved_state)
     return predictor

--- a/src/proverbot9001.py
+++ b/src/proverbot9001.py
@@ -67,7 +67,7 @@ def train(args):
                         list(evaluate_state.trainable_modules.keys()))
     arg_values = parser.parse_args(args[:1])
     if arg_values.model in predict_tactic.trainable_modules.keys():
-        predict_tactic.trainable_modules[arg_values.model](args[1:])
+        loadTrainablePredictor(arg_values.model)(args[1:])
     elif arg_values.model in evaluate_state.trainable_modules.keys():
         evaluate_state.trainable_modules[arg_values.model](args[1:])
     else:

--- a/src/rl.py
+++ b/src/rl.py
@@ -244,6 +244,9 @@ def reinforce_jobs(args: argparse.Namespace) -> None:
         else:
             args.resume = "no"
     elif not args.output_file.exists():
+        assert args.resume != "yes", \
+                "Can't resume because output file " \
+                f"{args.output_file} doesn't already exist."
         args.resume = "no"
 
     if args.resume == "yes":

--- a/src/rl.py
+++ b/src/rl.py
@@ -437,7 +437,7 @@ def experience_proof(args: argparse.Namespace,
         if args.verbose >= 3:
             coq_serapy.summarizeContext(coq.proof_context)
         actions = predictor.predictKTactics(
-            truncate_tactic_context(FullContext(coq.local_lemmas,
+            truncate_tactic_context(FullContext(coq.local_lemmas[:-1],
                                                 coq.prev_tactics,
                                                 unwrap(coq.proof_context)).as_tcontext(),
                                     30),
@@ -649,7 +649,7 @@ def evaluate_proof(args: argparse.Namespace,
     for _step in range(args.steps_per_episode):
         actions = predictor.predictKTactics(
             truncate_tactic_context(FullContext(
-                coq.local_lemmas,
+                coq.local_lemmas[:-1],
                 coq.prev_tactics,
                 unwrap(coq.proof_context)).as_tcontext(),
                                     30),

--- a/src/rl.py
+++ b/src/rl.py
@@ -517,7 +517,7 @@ def action_result(coq: coq_serapy.CoqAgent, path: List[ProofContext],
         eprint(f"Action produced error {e}", guard=verbosity >= 3)
         return None
     context_after = coq.proof_context
-    coq.cancel_last()
+    coq.cancel_last_noupdate()
     if any(coq_serapy.contextSurjective(context_after, path_context)
            for path_context in path):
         return None

--- a/src/rl.py
+++ b/src/rl.py
@@ -117,6 +117,10 @@ class FileReinforcementWorker(Worker):
         else:
             with print_time("Traversing to tactic prefix"):
                 cur_path = self.coq.tactic_history.getFullHistory()[1:]
+                # this is needed because commands that are just comments don't
+                # show up in the history (because cancelling skips them).
+                target_path = [tac for tac in tactic_prefix
+                               if coq_serapy.kill_comments(tac).strip() != ""]
                 common_prefix_len = 0
                 for item1, item2 in zip(cur_path, tactic_prefix):
                     if item1 != item2:

--- a/src/rl.py
+++ b/src/rl.py
@@ -454,11 +454,11 @@ def experience_proof(args: argparse.Namespace,
             for action in random.sample(actions, k=len(actions)):
                 try:
                     coq.run_stmt(action.prediction)
-                    if any(coq_serapy.contextSurjective(coq.proof_context, path_context)
+                    resulting_context = coq.proof_context
+                    coq.cancel_last_noupdate()
+                    if any(coq_serapy.contextSurjective(resulting_context, path_context)
                            for path_context in path):
-                        coq.cancel_last()
                         continue
-                    coq.cancel_last()
                     chosen_action = action
                     break
                 except (coq_serapy.CoqTimeoutError, coq_serapy.ParseError,

--- a/src/rl.py
+++ b/src/rl.py
@@ -12,11 +12,14 @@ from operator import itemgetter
 from typing import (List, Optional, Dict, Tuple, Union, Any, Set,
                     Sequence, TypeVar, Callable)
 
-import torch
-from torch import nn
-import torch.nn.functional as F
-from torch import optim
-import torch.optim.lr_scheduler as scheduler
+from util import unwrap, eprint, print_time, nostderr
+
+with print_time("Importing torch"):
+    import torch
+    from torch import nn
+    import torch.nn.functional as F
+    from torch import optim
+    import torch.optim.lr_scheduler as scheduler
 
 from tqdm import tqdm
 
@@ -31,7 +34,6 @@ from search_strategies import completed_proof
 
 from models.tactic_predictor import (TacticPredictor, Prediction)
 
-from util import unwrap, eprint, print_time, nostderr
 
 def main():
     parser = argparse.ArgumentParser(

--- a/src/rl.py
+++ b/src/rl.py
@@ -122,8 +122,8 @@ class FileReinforcementWorker(Worker):
                 target_path = [tac for tac in tactic_prefix
                                if coq_serapy.kill_comments(tac).strip() != ""]
                 common_prefix_len = 0
-                for item1, item2 in zip(cur_path, tactic_prefix):
-                    if item1 != item2:
+                for item1, item2 in zip(cur_path, target_path):
+                    if item1.strip() != item2.strip():
                         break
                     common_prefix_len += 1
                 for _ in range(len(cur_path) - common_prefix_len):

--- a/src/rl.py
+++ b/src/rl.py
@@ -11,7 +11,6 @@ from pathlib import Path
 from operator import itemgetter
 from typing import (List, Optional, Dict, Tuple, Union, Any, Set,
                     Sequence, TypeVar, Callable)
-from taskhandler import Taskhandler
 
 import torch
 from torch import nn

--- a/src/search_worker.py
+++ b/src/search_worker.py
@@ -135,12 +135,6 @@ class Worker:
         assert self.coq
         assert not self.coq.proof_context, "Already in a proof!"
         job_project, job_file, job_module, job_lemma = job
-        # Filter lemmas out of lemmas_encountered that occur after the target
-        # lemma.
-        self.lemmas_encountered = \
-                {lemma: state
-                 for lemma, state in self.lemmas_encountered.items()
-                 if state <= state_before_lemma}
         lemma_name = coq_serapy.lemma_name_from_statement(job_lemma)
         for i in range(len(self.coq._file_state.local_lemmas)):
             ll_sm_stack, ll_lemma_hyp, ll_is_sec_local = self.coq._file_state.local_lemmas[-1]
@@ -169,8 +163,14 @@ class Worker:
         # Get the state number from before the lemma from our dict.
         checkjob = ReportJob(job_project, job_file, job_module, coq_serapy.kill_comments(job_lemma).strip())
         state_before_lemma = self.lemmas_encountered[checkjob]
+        # Filter lemmas out of lemmas_encountered that occur after the target
+        # lemma.
+        self.lemmas_encountered = \
+                {lemma: state
+                 for lemma, state in self.lemmas_encountered.items()
+                 if state <= state_before_lemma}
         try:
-            # Reset to that state number
+            # Reset to the state number before the target lemma
             self.coq.run_stmt(f"BackTo {state_before_lemma}.")
             # Finally run the lemma statement
             self.coq.run_stmt(job_lemma)

--- a/src/search_worker.py
+++ b/src/search_worker.py
@@ -252,6 +252,7 @@ class Worker:
                     return
                 assert False
             except coq_serapy.SerapiException:
+                raise
                 if not careful:
                     eprint("Hit a problem, possibly due to admitting proofs! "
                            "Restarting file with --careful...",

--- a/src/search_worker.py
+++ b/src/search_worker.py
@@ -313,7 +313,7 @@ class Worker:
         ending_command = None
         important_vernac_cmds = []
         for cmd in self.remaining_commands:
-            if re.match("\s*(?:Opaque|Transparent)\s+[\w']+\.", cmd):
+            if re.match("\s*(?:Local|Global\s+)?(?:Opaque|Transparent)\s+[\w']+\.", cmd):
                 important_vernac_cmds.append(cmd)
             if coq_serapy.ending_proof(cmd):
                 ending_command = cmd

--- a/src/search_worker.py
+++ b/src/search_worker.py
@@ -310,7 +310,10 @@ class Worker:
         assert self.coq
         lemma_statement = self.coq.prev_tactics[0]
         ending_command = None
+        important_vernac_cmds = []
         for cmd in self.remaining_commands:
+            if re.match("\s*(?:Opaque|Transparent)\s+[\w']+\.", cmd):
+                important_vernac_cmds.append(cmd)
             if coq_serapy.ending_proof(cmd):
                 ending_command = cmd
                 break
@@ -343,6 +346,8 @@ class Worker:
                 starting_command = coq_serapy.kill_comments(self.remaining_commands[0]).strip()
                 if starting_command.startswith("Proof"):
                     self.coq.run_stmt(starting_command)
+                for cmd in important_vernac_cmds:
+                    self.coq.run_stmt(cmd)
                 if not coq_serapy.ending_proof(starting_command):
                     coq_serapy.admit_proof(self.coq, lemma_statement, ending_command)
             except coq_serapy.SerapiException:

--- a/src/search_worker.py
+++ b/src/search_worker.py
@@ -275,21 +275,7 @@ class Worker:
                coq_serapy.kill_comments(job_lemma).strip() and \
               self.coq.sm_prefix == job_module:
                 return
-            try:
-                self.skip_proof(careful)
-            except coq_serapy.SerapiException:
-                if not careful:
-                    eprint("Hit a problem, possibly due to admitting proofs! "
-                           "Restarting file with --careful...",
-                           guard=self.args.verbose >= 1)
-                    self.reset_file_state()
-                    self.exit_cur_file()
-                    self.enter_file(job_file)
-                    self.run_into_job(job, restart_anomaly, True)
-                    return
-                eprint(f"Failed getting to before: {job_lemma}")
-                eprint(f"In file {job_file}")
-                raise
+            self.skip_proof(careful)
 
     def skip_proof(self, careful: bool) -> None:
         assert self.coq

--- a/src/search_worker.py
+++ b/src/search_worker.py
@@ -309,7 +309,7 @@ class Worker:
 
     def skip_proof(self, careful: bool) -> None:
         assert self.coq
-        lemma_statement = self.coq.prev_tactics[0]
+        lemma_statement = coq_serapy.kill_comments(self.coq.prev_tactics[0]).strip()
         ending_command = None
         important_vernac_cmds = []
         for cmd in self.remaining_commands:
@@ -325,15 +325,10 @@ class Worker:
         # table of lemma dependencies for recursive use of section
         # variables.
         proof_relevant = ending_command.strip() == "Defined." or \
-            bool(re.match(
-                r"\s*Derive",
-                coq_serapy.kill_comments(lemma_statement))) or \
-            bool(re.match(
-                r"\s*Let",
-                coq_serapy.kill_comments(lemma_statement))) or \
-            bool(re.match(
-                r"\s*Equations",
-                coq_serapy.kill_comments(lemma_statement))) or \
+            bool(re.match(r"\s*Derive", lemma_statement)) or \
+            bool(re.match(r"\s*Let", lemma_statement)) or \
+            bool(re.match(r"\s*Equations", lemma_statement)) or \
+            bool(re.match(r"\s*Next\s+Obligation", lemma_statement)) or \
             careful
         if proof_relevant:
             while len(self.coq.prev_tactics) > 1:

--- a/src/search_worker.py
+++ b/src/search_worker.py
@@ -39,7 +39,7 @@ class Worker:
     cur_project: Optional[str]
     cur_file: Optional[str]
     last_program_statement: Optional[str]
-    lemmas_encountered: List[ReportJob]
+    lemmas_encountered: Dict[ReportJob, int]
     remaining_commands: List[str]
     original_commands: List[str]
     obligation_num: int
@@ -51,7 +51,7 @@ class Worker:
         self.cur_file: Optional[str] = None
         self.cur_project: Optional[str] = None
         self.last_program_statement: Optional[str] = None
-        self.lemmas_encountered: List[ReportJob] = []
+        self.lemmas_encountered: Dict[ReportJob, int] = {}
         self.remaining_commands: List[str] = []
         self.obligation_num = 0
         self.switch_dict = switch_dict
@@ -114,7 +114,7 @@ class Worker:
 
     def reset_file_state(self) -> None:
         self.last_program_statement = None
-        self.lemmas_encountered = []
+        self.lemmas_encountered = {}
         self.remaining_commands = []
         self.obligation_num = 0
 
@@ -134,72 +134,57 @@ class Worker:
     def run_backwards_into_job(self, job: ReportJob, restart_anomaly: bool = True) -> None:
         assert self.coq
         assert not self.coq.proof_context, "Already in a proof!"
-
         job_project, job_file, job_module, job_lemma = job
+        # Filter lemmas out of lemmas_encountered that occur after the target
+        # lemma.
+        self.lemmas_encountered = \
+                {lemma: state
+                 for lemma, state in self.lemmas_encountered.items()
+                 if state <= state_before_lemma}
+        lemma_name = coq_serapy.lemma_name_from_statement(job_lemma)
+        for i in range(len(self.coq._file_state.local_lemmas)):
+            ll_sm_stack, ll_lemma_hyp, ll_is_sec_local = self.coq._file_state.local_lemmas[-1]
+            ll_sm_prefix = ".".join([mod for mod, is_section in ll_sm_stack]) + "."
+            ll_lemma_name = coq_serapy.get_var_term_in_hyp(ll_lemma_hyp)
+            if ll_lemma_name == lemma_name and ll_sm_prefix == job_module:
+                break
+            self.coq._file_state.local_lemmas.pop()
+        assert len(self.coq._file_state.local_lemmas) > 0, "Couldn't find lemma!"
+
+        # Set self.remaining_commands to the commands after the lemma we're
+        # cancelling into.
         all_file_commands = self.original_commands
         commands_after_lemma_start = list(all_file_commands)
         sm_stack = coq_serapy.initial_sm_stack(job_file)
         while (coq_serapy.sm_prefix_from_stack(sm_stack) != job_module or
                coq_serapy.kill_comments(commands_after_lemma_start[0]).strip() !=
-               coq_serapy.kill_comments(job_lemma).strip()):
+               coq_serapy.kill_comments(job.lemma_statement).strip()):
             next_cmd = commands_after_lemma_start.pop(0)
             sm_stack = coq_serapy.update_sm_stack(sm_stack, next_cmd)
-        commands_to_cancel = commands_after_lemma_start[:len(commands_after_lemma_start)-len(self.remaining_commands)]
-        commands_before_point = list(all_file_commands[:len(all_file_commands)-len(self.remaining_commands)])
-        
-        while len(commands_to_cancel) > 0:
-            try :
-                if coq_serapy.ending_proof(commands_to_cancel[-1]):
-                    while not coq_serapy.possibly_starting_proof(commands_to_cancel[-1]):
-                        popped = commands_to_cancel.pop(-1)
-                        commands_before_point.pop(-1)
-                    cancelled_lemma_statement = commands_to_cancel.pop(-1)
-                    commands_before_point.pop(-1)
-                    last_lemma_encountered = self.lemmas_encountered.pop()
-                    assert coq_serapy.kill_comments(cancelled_lemma_statement).strip() in \
-                        [coq_serapy.kill_comments(last_lemma_encountered.lemma_statement).strip(),
-                        "Next Obligation."], \
-                        f"Last lemma encountered was {last_lemma_encountered.lemma_statement}, " \
-                        f"but cancelling {cancelled_lemma_statement}"
-
-                    assert not self.coq.proof_context
-                    # Sometimes a Qed in file corresponds to two commands
-                    # in our coqagent history, because of the way we need
-                    # to Admit Let's
-                    while not self.coq.proof_context:
-                        self.coq.cancel_last()
-                    while self.coq.proof_context:
-                        self.coq.cancel_last()
-                    self.coq._file_state.cancel_potential_local_lemmas(
-                        cancelled_lemma_statement, commands_before_point)
-                else:
-                    self.coq.cancel_last()
-                    cancelled_cmd = coq_serapy.kill_comments(commands_to_cancel.pop(-1)).strip()
-                    commands_before_point.pop(-1)
-                    newstack = \
-                        coq_serapy.coq_util.cancel_update_sm_stack(
-                            self.coq._file_state.sm_stack,
-                            cancelled_cmd, commands_before_point)
-
-                    if newstack != self.coq._file_state.sm_stack:
-                        self.coq._file_state.sm_stack = newstack
-            except coq_serapy.CoqAnomaly as e:
-                if restart_anomaly:
-                    self.restart_coq()
-                    self.reset_file_state()
-                    self.enter_file(job_file)
-                    eprint("Hit a coq anomaly! Restarting...",
-                        guard=self.args.verbose >= 1)
-                    self.run_into_job(job, True, False)
-                    return
-                eprint(e)
-                assert False
-
-        self.coq.run_stmt(job_lemma)
         self.remaining_commands = commands_after_lemma_start
-        appendjob = ReportJob(job_project, job_file, job_module, coq_serapy.kill_comments(job_lemma).strip())
-        self.lemmas_encountered.append(appendjob)
+        # Reset the sm stack in Coq to the one from the command we're
+        # cancelling to.
+        self.coq._file_state.sm_stack = sm_stack
 
+        # Get the state number from before the lemma from our dict.
+        checkjob = ReportJob(job_project, job_file, job_module, coq_serapy.kill_comments(job_lemma).strip())
+        state_before_lemma = self.lemmas_encountered[checkjob]
+        try:
+            # Reset to that state number
+            self.coq.run_stmt(f"BackTo {state_before_lemma}.")
+            # Finally run the lemma statement
+            self.coq.run_stmt(job_lemma)
+        except coq_serapy.CoqAnomaly as e:
+            if restart_anomaly:
+                self.restart_coq()
+                self.reset_file_state()
+                self.enter_file(job_file)
+                eprint("Hit a coq anomaly! Restarting...",
+                    guard=self.args.verbose >= 1)
+                self.run_into_job(job, True, False)
+                return
+            eprint(e)
+            assert False
 
     def run_into_job(self, job: ReportJob, restart_anomaly: bool, careful: bool) -> None:
         assert self.coq
@@ -236,10 +221,8 @@ class Worker:
                     "Currently in a proof! Back up to before the current proof, "\
                     "or use coq.finish_proof(cmds) or " \
                     "admit_proof(coq, lemma_statement, ending_stmt)"
-                rest_commands, run_commands = \
-                    unwrap(cast(Optional[Tuple[List[str], List[str]]],
-                                self.coq.run_into_next_proof(
-                                    self.remaining_commands)))
+                rest_commands, run_commands, state_before_proof = \
+                    self.coq.run_into_next_proof(self.remaining_commands)
                 assert rest_commands, f"Couldn't find lemma {job_lemma}"
             except coq_serapy.CoqAnomaly:
                 if restart_anomaly:
@@ -283,13 +266,14 @@ class Worker:
             else:
                 unique_lemma_statement = lemma_statement
             self.remaining_commands = rest_commands
+            norm_job = ReportJob(self.cur_project,
+                                 unwrap(self.cur_file),
+                                 self.coq.sm_prefix,
+                                 coq_serapy.kill_comments(unique_lemma_statement).strip())
+            self.lemmas_encountered[norm_job] = state_before_proof
             if coq_serapy.kill_comments(unique_lemma_statement).strip() == \
                coq_serapy.kill_comments(job_lemma).strip() and \
               self.coq.sm_prefix == job_module:
-                self.lemmas_encountered.append(ReportJob(self.cur_project,
-                                                         unwrap(self.cur_file),
-                                                         self.coq.sm_prefix,
-                                                         coq_serapy.kill_comments(unique_lemma_statement).strip()))
                 return
             try:
                 self.skip_proof(careful)
@@ -354,10 +338,6 @@ class Worker:
                 self.remaining_commands.pop(0)
             # Pop the actual Qed/Defined/Save
             self.remaining_commands.pop(0)
-        self.lemmas_encountered.append(ReportJob(self.cur_project,
-                                                 self.cur_file, self.coq.sm_prefix,
-                                                 coq_serapy.kill_comments(lemma_statement).strip()))
-
 
 class SearchWorker(Worker):
     widx: int

--- a/src/search_worker.py
+++ b/src/search_worker.py
@@ -341,9 +341,10 @@ class Worker:
                 coq_serapy.lemma_name_from_statement(lemma_statement)
             try:
                 starting_command = coq_serapy.kill_comments(self.remaining_commands[0]).strip()
-                if starting_command.startswith("Proof") and not coq_serapy.ending_proof(starting_command):
+                if starting_command.startswith("Proof"):
                     self.coq.run_stmt(starting_command)
-                coq_serapy.admit_proof(self.coq, lemma_statement, ending_command)
+                if not coq_serapy.ending_proof(starting_command):
+                    coq_serapy.admit_proof(self.coq, lemma_statement, ending_command)
             except coq_serapy.SerapiException:
                 eprint(f"{self.cur_file}: Failed to admit proof {lemma_name}")
                 raise

--- a/src/torch_util.py
+++ b/src/torch_util.py
@@ -1,0 +1,101 @@
+
+from typing import overload, Callable, List, Tuple
+
+import torch
+import torch.cuda
+import torch.autograd as autograd
+
+from util import silent
+
+def str_1d_long_tensor(tensor : torch.LongTensor):
+    if (type(tensor) == autograd.Variable):
+        tensor = tensor.data
+    tensor = tensor.view(-1)
+    return str(list(tensor))
+
+def str_1d_float_tensor(tensor : torch.FloatTensor):
+    if (type(tensor) == autograd.Variable):
+        tensor = tensor.data
+    tensor = tensor.view(-1)
+    output = io.StringIO()
+    print("[", end="", file=output)
+    if tensor.size()[0] > 0:
+        print("{:.4f}".format(tensor[0]), end="", file=output)
+    for f in tensor[1:]:
+        print(", {:.4f}".format(f), end="", file=output)
+    print("]", end="", file=output)
+    result = output.getvalue()
+    output.close()
+    return result
+
+@overload
+def _inflate(tensor : torch.LongTensor, times : int) -> torch.LongTensor: ...
+@overload
+def _inflate(tensor : torch.FloatTensor, times : int) -> torch.FloatTensor: ...
+
+def _inflate(tensor : torch.Tensor, times : int) -> torch.Tensor:
+    tensor_dim = len(tensor.size())
+    if tensor_dim == 3:
+        b = tensor.size(1)
+        return tensor.repeat(1, 1, times).view(tensor.size(0), b * times, -1)
+    elif tensor_dim == 2:
+        return tensor.repeat(1, times)
+    elif tensor_dim == 1:
+        b = tensor.size(0)
+        return tensor.repeat(times).view(b, -1)
+    else:
+        raise ValueError("Tensor can be of 1D, 2D, or 3D only. "
+                         "This one is {}D.".format(tensor_dim))
+
+def topk_with_filter(t : torch.FloatTensor, k : int, f : Callable[[float, int], bool]) \
+    -> Tuple[torch.FloatTensor, torch.LongTensor]:
+    all_certainties, all_idxs = t.topk(t.size()[0])
+    certainties = []
+    idxs = []
+    for certainty, idx in zip(all_certainties, all_idxs):
+        if f(certainty.item(), idx.item()):
+            certainties.append(certainty)
+            idxs.append(idx)
+            if len(certainties) == k:
+                break
+    return FloatTensor(certainties), LongTensor(idxs)
+
+with silent():
+    use_cuda = torch.cuda.is_available()
+    cuda_device = "cuda:0"
+
+    # we want to use this in modules,
+    # but we also want to compile those modules.
+
+    # pytorch is extremely unhappy with references to
+    # global variables.
+
+    # therefore, we will bake the above static result
+    # into these functions right now.
+
+    if use_cuda:
+        def maybe_cuda(component):
+            return component.to(device=torch.device("cuda:0"))
+
+        def LongTensor(x : List[int]):
+            return torch.tensor(x,dtype=torch.long).to(device=torch.device("cuda:0"))
+
+        def FloatTensor(x : List[float]):
+            return torch.tensor(x,dtype=torch.float32).to(device=torch.device("cuda:0"))
+
+        def ByteTensor(x : List[int]):
+            return torch.tensor(x,dtype=torch.uint8).to(device=torch.device("cuda:0"))
+    else:
+        def maybe_cuda(component):
+                return component
+
+        def LongTensor(x : List[int]):
+            return torch.tensor(x,dtype=torch.long)
+
+        def FloatTensor(x : List[float]):
+            return torch.tensor(x,dtype=torch.float32)
+
+        def ByteTensor(x : List[int]):
+            return torch.tensor(x,dtype=torch.uint8)
+    # now these can be easily compiled into torchscript.
+

--- a/src/util.py
+++ b/src/util.py
@@ -32,10 +32,6 @@ from datetime import datetime, timedelta
 from typing import (List, Tuple, Iterable, Any, overload, TypeVar,
                     Callable, Optional, Pattern, Match, Union)
 
-import torch
-import torch.cuda
-import torch.autograd as autograd
-
 from sexpdata import Symbol
 from dataloader import rust_parse_sexp_one_level
 from pathlib import Path
@@ -58,46 +54,6 @@ def timeSince(since : float, percent : float) -> str:
     rs = es - s
     return "{} (- {})".format(asMinutes(s), asMinutes(rs))
 
-def str_1d_long_tensor(tensor : torch.LongTensor):
-    if (type(tensor) == autograd.Variable):
-        tensor = tensor.data
-    tensor = tensor.view(-1)
-    return str(list(tensor))
-
-def str_1d_float_tensor(tensor : torch.FloatTensor):
-    if (type(tensor) == autograd.Variable):
-        tensor = tensor.data
-    tensor = tensor.view(-1)
-    output = io.StringIO()
-    print("[", end="", file=output)
-    if tensor.size()[0] > 0:
-        print("{:.4f}".format(tensor[0]), end="", file=output)
-    for f in tensor[1:]:
-        print(", {:.4f}".format(f), end="", file=output)
-    print("]", end="", file=output)
-    result = output.getvalue()
-    output.close()
-    return result
-
-@overload
-def _inflate(tensor : torch.LongTensor, times : int) -> torch.LongTensor: ...
-@overload
-def _inflate(tensor : torch.FloatTensor, times : int) -> torch.FloatTensor: ...
-
-def _inflate(tensor : torch.Tensor, times : int) -> torch.Tensor:
-    tensor_dim = len(tensor.size())
-    if tensor_dim == 3:
-        b = tensor.size(1)
-        return tensor.repeat(1, 1, times).view(tensor.size(0), b * times, -1)
-    elif tensor_dim == 2:
-        return tensor.repeat(1, times)
-    elif tensor_dim == 1:
-        b = tensor.size(0)
-        return tensor.repeat(times).view(b, -1)
-    else:
-        raise ValueError("Tensor can be of 1D, 2D, or 3D only. "
-                         "This one is {}D.".format(tensor_dim))
-
 T = TypeVar('T')
 def chunks(l : Iterable[T], chunk_size : int) -> Iterable[List[T]]:
     i = iter(l)
@@ -113,19 +69,6 @@ def list_topk(lst : List[T], k : int, f : Optional[Callable[[T], float]] = None)
     l = sorted(enumerate(lst), key=lambda x:f(x[1]), reverse=True) # type: ignore
     lk = l[:k]
     return tuple(zip(*lk)) # type: ignore
-
-def topk_with_filter(t : torch.FloatTensor, k : int, f : Callable[[float, int], bool]) \
-    -> Tuple[torch.FloatTensor, torch.LongTensor]:
-    all_certainties, all_idxs = t.topk(t.size()[0])
-    certainties = []
-    idxs = []
-    for certainty, idx in zip(all_certainties, all_idxs):
-        if f(certainty.item(), idx.item()):
-            certainties.append(certainty)
-            idxs.append(idx)
-            if len(certainties) == k:
-                break
-    return FloatTensor(certainties), LongTensor(idxs)
 
 def multipartition(xs : List[T], f : Callable[[T], int]) -> List[List[T]]:
     result : List[List[T]] = []
@@ -199,47 +142,6 @@ def silent():
     finally:
         sys.stderr = save_stderr
         sys.stdout = save_stdout
-
-with silent():
-    use_cuda = torch.cuda.is_available()
-    cuda_device = "cuda:0"
-    
-    # we want to use this in modules,
-    # but we also want to compile those modules.
-
-    # pytorch is extremely unhappy with references to
-    # global variables.
-
-    # therefore, we will bake the above static result
-    # into these functions right now.
-
-    if use_cuda:
-        def maybe_cuda(component):
-            return component.to(device=torch.device("cuda:0"))
-
-        def LongTensor(x : List[int]):
-            return torch.tensor(x,dtype=torch.long).to(device=torch.device("cuda:0"))
-
-        def FloatTensor(x : List[float]):
-            return torch.tensor(x,dtype=torch.float32).to(device=torch.device("cuda:0"))
-
-        def ByteTensor(x : List[int]):
-            return torch.tensor(x,dtype=torch.uint8).to(device=torch.device("cuda:0"))
-    else:
-        def maybe_cuda(component):
-                return component
- 
-        def LongTensor(x : List[int]):
-            return torch.tensor(x,dtype=torch.long)
-
-        def FloatTensor(x : List[float]):
-            return torch.tensor(x,dtype=torch.float32)
-
-        def ByteTensor(x : List[int]):
-            return torch.tensor(x,dtype=torch.uint8)
-    # now these can be easily compiled into torchscript.
-
-
 
 import signal as sig
 @contextlib.contextmanager


### PR DESCRIPTION
Speeds up job traversal for reinforcement learning in several ways:
1. Moving between two tasks within the same proof uses the minimum number of cancellations and additions, instead of restarting the proof and running the entire new prefix.
2. When running tactic prefixes, uses run_stmt_noupdate to avoid parsing intermediary proof states, only updating the state after the prefix has been run.
3. Tracks the state number for each previously seen lemma in the file, allowing lemmas to be returned to with the BackTo vernacular command instead of having to cancel a bunch of commands individually. Not sure how this interacts with the coq-lsp backend, but that's a problem for another day.