### PR TITLE
Negative examples

### DIFF
--- a/dataloader/dataloader-core/src/features.rs
+++ b/dataloader/dataloader-core/src/features.rs
@@ -211,6 +211,9 @@ impl TokenMap {
             (self.hyp_token_to_index.len() + 1) as i64,
         ]
     }
+    pub fn prev_tactic_vocab_size(&self) -> i64 {
+        return (self.tactic_to_index.len() + 1) as i64
+    }
 
     pub fn to_dicts(&self) -> PickleableTokenMap {
         (

--- a/dataloader/dataloader-core/src/lib.rs
+++ b/dataloader/dataloader-core/src/lib.rs
@@ -201,6 +201,12 @@ fn dataloader(_py: Python, m: &PyModule) -> PyResult<()> {
         get_premise_features_size_rs(args, metadata)
     }
     #[pyfn(m)]
+    pub fn encode_prev_tactic(metadata: PickleableFPAMetadata,
+                              tactic: String) -> i64 {
+        let (_indexer, _tokenizer, ftmap) = fpa_metadata_from_pickleable(metadata);
+        prev_tactic_feature(&ftmap, &vec![tactic])
+    }
+    #[pyfn(m)]
     fn decode_fpa_stem(
         _py: Python,
         args: DataloaderArgs,
@@ -274,6 +280,11 @@ fn dataloader(_py: Python, m: &PyModule) -> PyResult<()> {
     fn get_word_feature_vocab_sizes(_py: Python, metadata: PickleableFPAMetadata) -> Vec<i64> {
         let (_indexer, _tokenizer, ftmap) = fpa_metadata_from_pickleable(metadata);
         ftmap.word_features_sizes()
+    }
+    #[pyfn(m)]
+    fn get_prev_tactic_vocab_size(metadata: PickleableFPAMetadata) -> i64 {
+        let (_indexer, _tokenizer, ftmap) = fpa_metadata_from_pickleable(metadata);
+        ftmap.prev_tactic_vocab_size()
     }
     #[pyfn(m)]
     fn get_vec_features_size(_py: Python, _metadata: PickleableFPAMetadata) -> i64 {

--- a/src/add_proof_using.py
+++ b/src/add_proof_using.py
@@ -54,7 +54,7 @@ def add_proof_using_with_running_instance(coq: coq_serapy.CoqAgent, commands: It
                     r"should start with one of the following commands:"
                     r"(?: |\n)Proof using\s*([^.]+)\.",
                     coq.backend.feedback_string, re.DOTALL)
-                if suggested_deps is not None:
+                if suggestion_match is not None:
                     suggested_deps = unwrap(suggestion_match).group(2)
                     if suggested_deps.strip() == "":
                         suggested_deps = "Type"

--- a/src/add_proof_using.py
+++ b/src/add_proof_using.py
@@ -54,18 +54,19 @@ def add_proof_using_with_running_instance(coq: coq_serapy.CoqAgent, commands: It
                     r"should start with one of the following commands:"
                     r"(?: |\n)Proof using\s*([^.]+)\.",
                     coq.backend.feedback_string, re.DOTALL)
-                suggested_deps = unwrap(suggestion_match).group(2)
-                if suggested_deps.strip() == "":
-                    suggested_deps = "Type"
-                proof_cmd_match = re.match(r"Proof(\s*[^.]*)\.",
-                                           cur_proof_commands[0].strip())
-                if proof_cmd_match:
-                    proof_cmd_suffix = proof_cmd_match.group(1)
-                    if len(suggested_deps.strip().split()) > 1 and proof_cmd_suffix.strip() != "":
-                        suggested_deps = "(" + suggested_deps + ")"
-                    cur_proof_commands[0] = "Proof using " + suggested_deps + proof_cmd_suffix + ".\n"
-                else:
-                    cur_proof_commands.insert(0, "Proof using " + suggested_deps + ".\n")
+                if suggested_deps is not None:
+                    suggested_deps = unwrap(suggestion_match).group(2)
+                    if suggested_deps.strip() == "":
+                        suggested_deps = "Type"
+                    proof_cmd_match = re.match(r"Proof(\s*[^.]*)\.",
+                                               cur_proof_commands[0].strip())
+                    if proof_cmd_match:
+                        proof_cmd_suffix = proof_cmd_match.group(1)
+                        if len(suggested_deps.strip().split()) > 1 and proof_cmd_suffix.strip() != "":
+                            suggested_deps = "(" + suggested_deps + ")"
+                        cur_proof_commands[0] = "Proof using " + suggested_deps + proof_cmd_suffix + ".\n"
+                    else:
+                        cur_proof_commands.insert(0, "Proof using " + suggested_deps + ".\n")
 
             yield from cur_proof_commands
             cur_proof_commands = []

--- a/src/distributed_rl_acting_worker.py
+++ b/src/distributed_rl_acting_worker.py
@@ -25,7 +25,7 @@ sys.path.append(str(Path(os.getcwd()) / "src"))
 #pylint: disable=wrong-import-position
 import distributed_rl as drl
 import rl
-from gen_rl_tasks import RLTask
+from gen_rl_tasks import RLTask, ProofSpec
 from models.tactic_predictor import TacticPredictor
 from search_worker import get_predictor
 from util import FileLock, eprint, safe_abbrev, print_time, unwrap
@@ -380,7 +380,6 @@ def allocate_next_task_from_file_with_retry(
   assert False
   return None
 
-ProofSpec = Tuple[str, str, str]
 ProofEpisodeSpec = Tuple[ProofSpec, int]
 
 def allocate_next_task_from_file(args: argparse.Namespace,

--- a/src/distributed_rl_acting_worker.py
+++ b/src/distributed_rl_acting_worker.py
@@ -27,6 +27,7 @@ import distributed_rl as drl
 import rl
 from gen_rl_tasks import RLTask, ProofSpec
 from models.tactic_predictor import TacticPredictor
+from models.features_polyarg_predictor import FeaturesPolyargPredictor
 from search_worker import get_predictor
 from util import FileLock, eprint, safe_abbrev, print_time, unwrap
 #pylint: enable=wrong-import-position
@@ -50,6 +51,7 @@ def main() -> None:
   parser.add_argument("-n", "--num-episodes", type=int)
   parser.add_argument("-p", "--num-predictions", type=int)
   parser.add_argument("--hidden-size", type=int, default=128)
+  parser.add_argument("--tactic-embedding-size", type=int, default=32)
   parser.add_argument("--num-layers", type=int, default=3)
   parser.add_argument("--optimizer", choices=rl.optimizers.keys(),
                       default=list(rl.optimizers.keys())[0])
@@ -85,10 +87,15 @@ def main() -> None:
   sys.exit(0)
 
 def reinforcement_act(args: argparse.Namespace, workerid: int) -> None:
-  learning_connection = LearningServerConnection(
-    args.coq2vec_weights)
   task_eps = drl.get_all_task_episodes(args)
   actor = initialize_actor(args)
+  assert isinstance(actor.predictor, rl.MemoizingPredictor), \
+                    type(actor.predictor)
+  assert isinstance(actor.predictor.underlying_predictor,
+                    FeaturesPolyargPredictor), \
+         type(actor.predictor.underlying_predictor)
+  learning_connection = LearningServerConnection(
+    args.coq2vec_weights, actor.predictor.underlying_predictor)
   task_state = TaskState(task_eps)
   all_files = task_state.all_files()
   while True:
@@ -103,16 +110,20 @@ def reinforcement_act(args: argparse.Namespace, workerid: int) -> None:
     successful, samples, negative_samples = actor.run_task_reinforce(
       next_task, cur_epsilon)
     if next_ep == 0:
-      learning_connection.encode_and_send_target_length(samples[0][0],
+      prev_tactic = (next_task.tactic_prefix[-1]
+                    if len(next_task.tactic_prefix) > 0 else "Proof.")
+      learning_connection.encode_and_send_target_length(prev_tactic,
+                                                        samples[0][1],
                                                         next_task.target_length)
     if successful and len(samples) < next_task.target_length:
       update_shorter_proofs_dict(args, all_files, next_task, len(samples),
-                                 samples[0][0],
+                                 samples[0][1],
                                  learning_connection)
-    for prestate, action, poststates in samples:
-      learning_connection.encode_and_send_sample(prestate, action, poststates)
-    for state in negative_samples:
-      learning_connection.encode_and_send_negative_sample(state)
+    for prev_tactic, prestate, action, poststates in samples:
+      learning_connection.encode_and_send_sample(prev_tactic, prestate,
+                                                 action, poststates)
+    for prev_tactic, state in negative_samples:
+      learning_connection.encode_and_send_negative_sample(prev_tactic, state)
     mark_task_done(args, workerid, next_task_ep)
     load_latest_q_network(args, actor.v_network)
 
@@ -141,11 +152,12 @@ class RLActor:
       self.file_workers.move_to_end(filename)
     if len(self.file_workers) > self.args.max_sertop_workers:
       filename, evicted_worker = self.file_workers.popitem(last=False)
-      evicted_worker.coq.kill()
+      unwrap(evicted_worker.coq).kill()
     return self.file_workers[filename]
   def run_task_reinforce(self, task: RLTask, epsilon: float,
                          restart: bool = True) -> \
-      Tuple[bool, List[Tuple[Obligation, str, List[Obligation]]], List[Obligation]]:
+      Tuple[bool, List[Tuple[str, Obligation, str, List[Obligation]]],
+                  List[Tuple[str, Obligation]]]:
     if not rl.tactic_prefix_is_usable(task.tactic_prefix):
       if self.args.verbose >= 2:
         eprint(f"Skipping job {task.to_job()} with prefix {task.tactic_prefix} "
@@ -154,7 +166,7 @@ class RLActor:
         eprint("Skipping a job because it can't be purely focused")
       return False, [], []
     with print_time("Getting worker", guard=self.args.print_timings):
-      file_worker = self._get_worker(task.src_file)
+      file_worker = self._get_worker(str(task.src_file))
     assert file_worker.coq is not None
     try:
       with print_time("Running into task", guard=self.args.print_timings):
@@ -166,7 +178,7 @@ class RLActor:
       eprint("Encountered Coq anomaly.")
       file_worker.restart_coq()
       file_worker.reset_file_state()
-      file_worker.enter_file(task.src_file)
+      file_worker.enter_file(str(task.src_file))
       if restart:
         return self.run_task_reinforce(task, epsilon, restart=False)
       eprint("Encountered anomaly without restart, closing current job")
@@ -186,7 +198,10 @@ def task_eps_as_dict(task_episodes: List[TaskEpisode]) \
 
 class LearningServerConnection:
   obligation_encoder: coq2vec.CoqContextVectorizer
-  def __init__(self, coq2vec_weights: Path, backend='mpi') -> None:
+  predictor: FeaturesPolyargPredictor
+  def __init__(self, coq2vec_weights: Path,
+               predictor: FeaturesPolyargPredictor,
+               backend='mpi') -> None:
     term_encoder = coq2vec.CoqTermRNNVectorizer()
     device = "cuda" if torch.cuda.is_available() else "cpu"
     term_encoder.load_state(torch.load(str(coq2vec_weights), map_location=device))
@@ -195,41 +210,70 @@ class LearningServerConnection:
     eprint("Establishing connection")
     dist.init_process_group(backend)
     eprint("Connection Initialized")
+    self.predictor = predictor
     pass
-  def send_sample(self, pre_state_encoded: torch.FloatTensor,
+  def send_sample(self, prev_tactic_encoded: int,
+                  pre_state_encoded: torch.FloatTensor,
+                  action_hashed: int,
                   action_encoded: int,
                   post_state_encodeds: List[torch.FloatTensor]) -> None:
-    dist.send(tensor=torch.tensor(0, dtype=int), tag=4, dst=0)
-    dist.send(tensor=pre_state_encoded, tag=0, dst=0)
-    dist.send(tensor=torch.LongTensor([action_encoded]), tag=1, dst=0)
-    dist.send(tensor=torch.LongTensor([len(post_state_encodeds)]), tag=2, dst=0)
+    dist.send(tensor=torch.LongTensor(0), tag=0, dst=0)
+    dist.send(tensor=torch.LongTensor([prev_tactic_encoded]),
+              tag=1, dst=0)
+    prestate_hash = hash(tuple(pre_state_encoded.view(-1).tolist() +
+                               [prev_tactic_encoded]))
+    eprint(f"Hash is {prestate_hash}")
+    dist.send(tensor=pre_state_encoded, tag=2, dst=0)
+    dist.send(tensor=torch.LongTensor([action_hashed]), tag=3, dst=0)
+    dist.send(tensor=torch.LongTensor([action_encoded]), tag=4, dst=0)
+    dist.send(tensor=torch.LongTensor([len(post_state_encodeds)]), tag=5, dst=0)
     for state in post_state_encodeds:
-      dist.send(tensor=state, tag=3, dst=0)
-  def encode_and_send_sample(self, pre_state: Obligation,
+      dist.send(tensor=state, tag=6, dst=0)
+  def encode_and_send_sample(self, prev_tactic: str,
+                             pre_state: Obligation,
                              action: str,
                              post_states: List[Obligation]) -> None:
+    prev_tactic_encoded = self.predictor.prev_tactic_stem_idx(prev_tactic)
+    action_encoded = self.predictor.prev_tactic_stem_idx(prev_tactic)
+    assert isinstance(self.obligation_encoder, rl.CachedObligationEncoder)
     states_encoded = self.obligation_encoder.obligations_to_vectors_cached(
       [pre_state] + post_states)
-    sample_hash = hash(tuple(states_encoded[0].view(-1).tolist()))
-    eprint(f"Sending sample {sample_hash} for obligation <{hash(pre_state)}> {pre_state.to_dict()}")
-    self.send_sample(states_encoded[0], hash(action), states_encoded[1:])
+    sample_hash = hash(tuple(states_encoded[0].view(-1).tolist() +
+                             [prev_tactic_encoded]))
+    eprint(f"Sending sample {sample_hash} for previous tactic {action_encoded}"
+           f" obligation <{hash(pre_state)}> {pre_state.to_dict()}")
+    self.send_sample(prev_tactic_encoded, states_encoded[0],
+                     hash(action), action_encoded, states_encoded[1:])
 
-  def send_target_v(self, state_encoded: torch.FloatTensor, target_length: int) -> None:
-    dist.send(tensor=torch.tensor(1, dtype=int), tag=4, dst=0)
-    dist.send(tensor=state_encoded, tag=5, dst=0)
-    dist.send(tensor=torch.tensor(target_length, dtype=int), tag=6, dst=0)
+  def send_target_v(self, prev_tactic: int,
+                    local_context_encoded: torch.FloatTensor,
+                    target_length: int) -> None:
+    dist.send(tensor=torch.tensor(1, dtype=int), tag=0, dst=0)
+    dist.send(tensor=torch.LongTensor([prev_tactic]), tag=10, dst=0)
+    dist.send(tensor=local_context_encoded, tag=11, dst=0)
+    dist.send(tensor=torch.tensor(target_length, dtype=int), tag=12, dst=0)
 
-  def encode_and_send_target_length(self, state: Obligation, target_length: int) -> None:
+  def encode_and_send_target_length(self, prev_tactic: str,
+                                    state: Obligation,
+                                    target_length: int) -> None:
+    prev_tactic_encoded = self.predictor.prev_tactic_stem_idx(prev_tactic)
+    assert isinstance(self.obligation_encoder, rl.CachedObligationEncoder)
     state_encoded = self.obligation_encoder.obligations_to_vectors_cached([state])[0]
-    self.send_target_v(state_encoded, target_length)
+    self.send_target_v(prev_tactic_encoded, state_encoded, target_length)
 
-  def encode_and_send_negative_sample(self, state: Obligation) -> None:
+  def encode_and_send_negative_sample(self, previous_tactic: str,
+                                      state: Obligation) -> None:
+    previous_tactic_encoded = self.predictor\
+                                  .prev_tactic_stem_idx(previous_tactic)
+    assert isinstance(self.obligation_encoder, rl.CachedObligationEncoder)
     state_encoded = self.obligation_encoder.\
       obligations_to_vectors_cached([state])[0]
-    sample_hash = hash(tuple(state_encoded.view(-1).tolist()))
-    eprint(f"Sending negative sample {sample_hash} for obligation <{hash(state)}> {state.to_dict()}")
-    dist.send(tensor=torch.tensor(2, dtype=int), tag=4, dst=0)
-    dist.send(tensor=state_encoded, tag=7, dst=0)
+    sample_hash = hash(tuple(state_encoded.view(-1).tolist() + [previous_tactic_encoded]))
+    eprint(f"Sending negative sample {sample_hash} for previous tactic "
+           f"{previous_tactic_encoded} obligation <{hash(state)}> {state.to_dict()}")
+    dist.send(tensor=torch.tensor(2, dtype=int), tag=0, dst=0)
+    dist.send(tensor=torch.LongTensor([previous_tactic_encoded]), tag=20, dst=0)
+    dist.send(tensor=state_encoded, tag=21, dst=0)
 
 @dataclass
 class FileTaskState:
@@ -479,13 +523,19 @@ def update_shorter_proofs_dict(args: argparse.Namespace,
     for task, shorter_length in shorter_proofs_dict.items():
       print(json.dumps((task.as_dict(), shorter_length)), file=shorter_proofs_handle)
 
-  server_connection.encode_and_send_target_length(starting_state, solution_length)
+  prev_tactic = (task.tactic_prefix[-1]
+                 if len(task.tactic_prefix) > 0 else "Proof.")
+  server_connection.encode_and_send_target_length(
+      prev_tactic, starting_state, solution_length)
 
 def initialize_actor(args: argparse.Namespace) \
     -> RLActor:
   predictor = rl.MemoizingPredictor(get_predictor(args))
-  network = rl.VNetwork(args.coq2vec_weights, 0.0,
-                        1, 1, args.optimizer,
+  assert isinstance(predictor.underlying_predictor, FeaturesPolyargPredictor)
+  network = rl.VNetwork(args.coq2vec_weights, predictor.underlying_predictor,
+                        0.0, 1, 1, args.optimizer,
+                        predictor.underlying_predictor.prev_tactic_vocab_size,
+                        args.tactic_embedding_size,
                         args.hidden_size, args.num_layers)
   load_latest_q_network(args, network)
   return RLActor(args, predictor, network)
@@ -508,23 +558,25 @@ def load_latest_q_network(args: argparse.Namespace, v_network: rl.VNetwork) -> N
     f"common-v-network-{newest_index}.dat")
   eprint(f"Loading latest q network from {latest_q_network_path}")
   q_network_state = torch.load(latest_q_network_path, map_location="cpu")
-  v_network.network.load_state_dict(q_network_state)
+  unwrap(v_network.network).load_state_dict(q_network_state)
 
 def experience_proof(args: argparse.Namespace,
                      coq: coq_serapy.CoqAgent,
                      predictor: TacticPredictor,
                      v_network: rl.VNetwork,
                      epsilon: float) \
-      -> Tuple[bool, List[Tuple[Obligation, str, List[Obligation]]], List[Obligation]]:
-  path: List[ProofContext] = [coq.proof_context]
-  initial_open_obligations = len(coq.proof_context.all_goals)
-  samples: List[Tuple[Obligation, str, List[Obligation]]] = []
-  negative_samples: List[Obligation] = []
+      -> Tuple[bool, List[Tuple[str, Obligation, str, List[Obligation]]],
+                     List[Tuple[str, Obligation]]]:
+  path: List[ProofContext] = [unwrap(coq.proof_context)]
+  initial_open_obligations = len(unwrap(coq.proof_context).all_goals)
+  samples: List[Tuple[str, Obligation, str, List[Obligation]]] = []
+  negative_samples: List[Tuple[str, Obligation]] = []
 
   for step in range(args.steps_per_episode):
     before_obl = unwrap(coq.proof_context).fg_goals[0]
+    before_prev_tactic = coq.prev_tactics[-1]
     if args.verbose >= 3:
-      coq_serapy.summarizeContext(coq.proof_context)
+      coq_serapy.summarizeContext(unwrap(coq.proof_context))
     tcontext = FullContext(coq.local_lemmas[:-1],
                            coq.prev_tactics,
                            unwrap(coq.proof_context)).as_tcontext()
@@ -540,6 +592,9 @@ def experience_proof(args: argparse.Namespace,
            guard=args.verbose >= 3)
     if random.random() < epsilon:
       eprint("Using best-scoring action", guard=args.verbose >= 3)
+      assert isinstance(predictor, rl.MemoizingPredictor)
+      assert isinstance(predictor.underlying_predictor,
+                        FeaturesPolyargPredictor)
       action_scores = rl.evaluate_actions(
         coq, v_network, path,
         [action.prediction for action in actions])
@@ -548,7 +603,7 @@ def experience_proof(args: argparse.Namespace,
       if chosen_score == -float("Inf"):
         eprint(f"Adding negative sample for obligation <{hash(before_obl)}> {before_obl.to_dict()}",
                guard=args.verbose>=3)
-        negative_samples.append(before_obl)
+        negative_samples.append((before_prev_tactic, before_obl))
         break
     else:
       eprint("Using random action", guard=args.verbose >=3)
@@ -556,7 +611,7 @@ def experience_proof(args: argparse.Namespace,
       for action in random.sample(actions, k=len(actions)):
         try:
           coq.run_stmt(action.prediction)
-          resulting_context = coq.proof_context
+          resulting_context = unwrap(coq.proof_context)
           coq.cancel_last_noupdate()
           if any(coq_serapy.contextSurjective(resulting_context, path_context)
                  for path_context in path):
@@ -571,20 +626,21 @@ def experience_proof(args: argparse.Namespace,
       if chosen_action is None:
         eprint(f"Adding negative sample for obligation <{hash(before_obl)}> {before_obl.to_dict()}",
                guard=args.verbose>=3)
-        negative_samples.append(before_obl)
+        negative_samples.append((before_prev_tactic, before_obl))
         break
+    assert chosen_action
     resuting_obls = rl.execute_action(coq, chosen_action.prediction)
     eprint(f"Taking action {chosen_action}",
            guard=args.verbose >= 2)
-    path.append(coq.proof_context)
+    path.append(unwrap(coq.proof_context))
     eprint(f"Adding positive sample for obligation <{hash(before_obl)}> {before_obl.to_dict()}",
            guard=args.verbose>=3)
-    samples.append((before_obl, chosen_action.prediction, resuting_obls))
-    if len(coq.proof_context.all_goals) < initial_open_obligations:
+    samples.append((before_prev_tactic, before_obl, chosen_action.prediction, resuting_obls))
+    if len(unwrap(coq.proof_context).all_goals) < initial_open_obligations:
       eprint(f"Completed task with trace {[sample[1] for sample in samples]}")
       return True, samples, negative_samples
-    assert len(coq.proof_context.all_goals) > 0
-    assert len(coq.proof_context.fg_goals) > 0
+    assert len(unwrap(coq.proof_context).all_goals) > 0
+    assert len(unwrap(coq.proof_context).fg_goals) > 0
   return False, samples, negative_samples
 if __name__ == "__main__":
   main()

--- a/src/distributed_rl_acting_worker.py
+++ b/src/distributed_rl_acting_worker.py
@@ -110,8 +110,7 @@ def reinforcement_act(args: argparse.Namespace, workerid: int) -> None:
     successful, samples, negative_samples = actor.run_task_reinforce(
       next_task, cur_epsilon)
     if next_ep == 0:
-      prev_tactic = (next_task.tactic_prefix[-1]
-                    if len(next_task.tactic_prefix) > 0 else "Proof.")
+      prev_tactic = rl.prev_tactic_from_prefix(next_task.tactic_prefix)
       learning_connection.encode_and_send_target_length(prev_tactic,
                                                         samples[0][1],
                                                         next_task.target_length)
@@ -523,8 +522,7 @@ def update_shorter_proofs_dict(args: argparse.Namespace,
     for task, shorter_length in shorter_proofs_dict.items():
       print(json.dumps((task.as_dict(), shorter_length)), file=shorter_proofs_handle)
 
-  prev_tactic = (task.tactic_prefix[-1]
-                 if len(task.tactic_prefix) > 0 else "Proof.")
+  prev_tactic = rl.prev_tactic_from_prefix(task.tactic_prefix)
   server_connection.encode_and_send_target_length(
       prev_tactic, starting_state, solution_length)
 

--- a/src/distributed_rl_learning_server.py
+++ b/src/distributed_rl_learning_server.py
@@ -351,7 +351,6 @@ class EncodedReplayBuffer:
   def add_transition(self, transition: EFullTransition) -> None:
     with self.lock:
       from_obl, action, _ = transition
-      eprint(f"Adding positive transition from {hash(from_obl)}")
       to_obls = tuple(transition[2])
       existing_entry = self._contents.get(from_obl, (0, set()))
       if from_obl in self._contents and len(existing_entry[1]) == 0:
@@ -359,25 +358,31 @@ class EncodedReplayBuffer:
                "but it's already marked as a negative example! Skipping...")
       # assert from_obl not in self._contents or len(existing_entry[1]) > 0
       for existing_action, existing_to_obls in existing_entry[1]:
-        if action == existing_action and to_obls != existing_to_obls:
-          eprint(f"WARNING: Transition from state {hash(from_obl)} "
-                 "clashed with previous entry! Skipping")
+        if action == existing_action:
+          if to_obls != existing_to_obls:
+            eprint(f"WARNING: Transition from state {hash(from_obl)} "
+                   "clashed with previous entry! Skipping")
           return
         # assert action != existing_action or to_obls == existing_to_obls,\
         #   f"From state {hash(from_obl)}, taking action has {action}, " \
         #   f"resulted in obls {[hash(obl) for obl in to_obls]}, " \
         #   "but in the past it resulted in obls " \
         #   f"{[hash(obl) for obl in existing_to_obls]}."
+      eprint(f"Adding positive transition from {hash(from_obl)}")
+
       self._contents[from_obl] = \
         (self.window_end_position,
          {(action, to_obls)} | existing_entry[1])
       self.window_end_position += 1
   def add_negative_sample(self, state: EObligation) -> None:
     with self.lock:
-      if state in self._contents and len(self._contents[state][1]) > 0:
-        eprint(f"WARNING: State {hash(state)} already had sample "
-               f"{self._contents[state]}, but we're trying to mark it as negative. "
-               "Skipping...")
+      if state in self._contents
+        if len(self._contents[state][1]) > 0:
+          eprint(f"WARNING: State {hash(state)} already had sample "
+                 f"{self._contents[state]}, but we're trying to mark it as negative. "
+                 "Skipping...")
+        return
+      eprint(f"Adding negative transition from {hash(state)}")
       # assert state not in self._contents or len(self._contents[state][1]) == 0, \
       #   f"State {hash(state)} already had sample {self._contents[state]}, but we're marking it as negative now"
       self._contents[state] = (self.window_end_position, set())

--- a/src/distributed_rl_learning_server.py
+++ b/src/distributed_rl_learning_server.py
@@ -176,9 +176,6 @@ def train(args: argparse.Namespace, v_model: VModel,
                                      in samples], dim=0)
   prev_tactic_indices = torch.LongTensor([start_obl.previous_tactic
                                           for start_obl, _ in samples]).to("cuda")
-  for prev_tactic_index in prev_tactic_indices:
-    assert prev_tactic_index < v_model.prev_tactic_vocab_size,\
-      prev_tactic_index
   num_resulting_obls = [[len(resulting_obls)
                          for _action, resulting_obls in action_records]
                         for _start_obl, action_records in samples]
@@ -193,9 +190,6 @@ def train(args: argparse.Namespace, v_model: VModel,
       resulting_prev_tactics_tensor = \
           torch.LongTensor([obl.previous_tactic for obl
                             in all_resulting_obls]).to("cuda")
-      for prev_tactic_index in resulting_prev_tactics_tensor:
-          assert prev_tactic_index < v_model.prev_tactic_vocab_size,\
-      prev_tactic_index
       all_obl_scores = target_model(resulting_local_contexts_tensor,
                                     resulting_prev_tactics_tensor)
   else:

--- a/src/distributed_rl_learning_server.py
+++ b/src/distributed_rl_learning_server.py
@@ -28,7 +28,7 @@ import torch.optim.lr_scheduler as scheduler
 print("Finished torch imports", file=sys.stderr)
 # pylint: disable=wrong-import-position
 sys.path.append(str(Path(os.getcwd()) / "src"))
-from rl import model_setup, optimizers, ReplayBuffer
+from rl import optimizers, ReplayBuffer, EObligation, VModel
 print("Imported rl model setup", file=sys.stderr)
 from util import eprint, unwrap, print_time
 # pylint: enable=wrong-import-position
@@ -44,6 +44,8 @@ def main() -> None:
   parser.add_argument("-b", "--batch-size", default=64, type=int)
   parser.add_argument("-g", "--gamma", default=0.9, type=float)
   parser.add_argument("--hidden-size", type=int, default=128)
+  parser.add_argument("--tactic-embedding-size", type=int, default=32)
+  parser.add_argument("--tactic-vocab-size", type=int)
   parser.add_argument("--num-layers", type=int, default=3)
   parser.add_argument("--allow-partial-batches", action='store_true')
   parser.add_argument("--window-size", type=int, default=2560)
@@ -75,8 +77,10 @@ def serve_parameters(args: argparse.Namespace, backend='mpi') -> None:
   eprint("Connection established")
   assert torch.cuda.is_available(), "Training node doesn't have CUDA available!" # type: ignore
   device = "cuda"
-  v_network: nn.Module = model_setup(args.encoding_size, args.hidden_size,
-                                     args.num_layers).to(device)
+  v_network: VModel = VModel(args.encoding_size, args.tactic_vocab_size,
+                             args.tactic_embedding_size,
+                             args.hidden_size,
+                             args.num_layers).to(device)
   if args.start_from is not None:
     _, _, _, network_state, \
       tnetwork_state, shorter_proofs_dict, _ = \
@@ -85,9 +89,10 @@ def serve_parameters(args: argparse.Namespace, backend='mpi') -> None:
     inner_network_state, _encoder_state, _obl_cache, \
       _hidden_size, _num_layers = network_state
     v_network.load_state_dict(inner_network_state)
-  target_network: nn.Module = model_setup(args.encoding_size,
-                                          args.hidden_size,
-                                          args.num_layers).to(device)
+  target_network: VModel = VModel(args.encoding_size, args.tactic_vocab_size,
+                             args.tactic_embedding_size,
+                             args.hidden_size,
+                             args.num_layers).to(device)
   target_network.load_state_dict(v_network.state_dict())
   optimizer: optim.Optimizer = optimizers[args.optimizer](v_network.parameters(),
                                                           lr=args.learning_rate)
@@ -156,7 +161,7 @@ def serve_parameters(args: argparse.Namespace, backend='mpi') -> None:
       print_vvalue_errors(args.gamma, v_network, buffer_thread.verification_states)
       last_iter_verified = iters_trained
 
-def train(args: argparse.Namespace, v_model: nn.Module,
+def train(args: argparse.Namespace, v_model: VModel,
           target_model: nn.Module,
           optimizer: optim.Optimizer,
           replay_buffer: EncodedReplayBuffer) -> Optional[torch.FloatTensor]:
@@ -164,23 +169,37 @@ def train(args: argparse.Namespace, v_model: nn.Module,
   if samples is None:
     return None
   eprint(f"Got {len(samples)} samples to train at step {replay_buffer.buffer_steps}")
-  inputs = torch.cat([start_obl.contents.view(1, args.encoding_size)
-                      for start_obl, _action_records in samples], dim=0)
+
+  local_contexts_encoded = torch.cat([start_obl.local_context
+                                               .view(1, args.encoding_size)
+                                     for start_obl, _action_records
+                                     in samples], dim=0)
+  prev_tactic_indices = torch.LongTensor([start_obl.previous_tactic
+                                          for start_obl, _ in samples]).to("cuda")
+  for prev_tactic_index in prev_tactic_indices:
+    assert prev_tactic_index < v_model.prev_tactic_vocab_size,\
+      prev_tactic_index
   num_resulting_obls = [[len(resulting_obls)
                          for _action, resulting_obls in action_records]
                         for _start_obl, action_records in samples]
-
   all_resulting_obls = [obl for _start_obl, action_records in samples
                         for _action, resulting_obls in action_records
                         for obl in resulting_obls]
   if len(all_resulting_obls) > 0:
     with torch.no_grad():
-      all_obls_tensor = torch.cat([obl.contents.view(1, args.encoding_size)
-                                   for obl in all_resulting_obls], dim=0)
-      eprint(all_obls_tensor)
-      all_obl_scores = target_model(all_obls_tensor)
+      resulting_local_contexts_tensor = \
+          torch.cat([obl.local_context.view(1, args.encoding_size)
+                     for obl in all_resulting_obls], dim=0)
+      resulting_prev_tactics_tensor = \
+          torch.LongTensor([obl.previous_tactic for obl
+                            in all_resulting_obls]).to("cuda")
+      for prev_tactic_index in resulting_prev_tactics_tensor:
+          assert prev_tactic_index < v_model.prev_tactic_vocab_size,\
+      prev_tactic_index
+      all_obl_scores = target_model(resulting_local_contexts_tensor,
+                                    resulting_prev_tactics_tensor)
   else:
-      all_obl_scores = []
+      all_obl_scores = torch.FloatTensor([])
   outputs = []
   cur_row = 0
   for resulting_obl_lens in num_resulting_obls:
@@ -193,7 +212,8 @@ def train(args: argparse.Namespace, v_model: nn.Module,
       action_outputs.append(args.gamma * math.prod(selected_obl_scores))
       cur_row += num_obls
     outputs.append(max(action_outputs))
-  actual_values = v_model(inputs).view(len(samples))
+  actual_values = v_model(local_contexts_encoded,
+                          prev_tactic_indices).view(len(samples))
   device = "cuda"
   target_values = torch.FloatTensor(outputs).to(device)
   loss: torch.FloatTensor = F.mse_loss(actual_values, target_values)
@@ -201,16 +221,6 @@ def train(args: argparse.Namespace, v_model: nn.Module,
   loss.backward()
   optimizer.step()
   return loss
-
-@dataclass
-class EObligation:
-  contents: torch.FloatTensor
-  def __hash__(self) -> int:
-    return hash(tuple(self.contents.view(-1).tolist()))
-  def __eq__(self, other: object) -> bool:
-    if not isinstance(other, EObligation):
-      return False
-    return bool(torch.all(self.contents == other.contents))
 
 class BufferPopulatingThread(Thread):
   replay_buffer: EncodedReplayBuffer
@@ -229,7 +239,7 @@ class BufferPopulatingThread(Thread):
   def run(self) -> None:
     while True:
       send_type = torch.zeros(1, dtype=int)
-      sending_worker = dist.recv(tensor=send_type, tag=4)
+      sending_worker = dist.recv(tensor=send_type, tag=0)
       if send_type.item() == 0:
         self.receive_experience_sample(sending_worker)
       elif send_type.item() == 1:
@@ -239,40 +249,53 @@ class BufferPopulatingThread(Thread):
         self.receive_negative_sample(sending_worker)
 
   def receive_experience_sample(self, sending_worker: int) -> None:
-    if self.ignore_after is not None and self.replay_buffer.buffer_steps >= self.ignore_after:
-        eprint("Ignoring a sample, but training anyway")
-        self.replay_buffer.buffer_steps += 1
-        self.signal_change.set()
-        return
     device = "cuda"
+    newest_prev_tactic_sample = torch.zeros(1, dtype=int)
+    dist.recv(tensor=newest_prev_tactic_sample, src=sending_worker, tag=1)
     newest_prestate_sample: torch.FloatTensor = \
       torch.zeros(self.encoding_size, dtype=torch.float32) #type: ignore
-    dist.recv(tensor=newest_prestate_sample, src=sending_worker, tag=0)
-    newest_action_sample = torch.zeros(1, dtype=int)
-    dist.recv(tensor=newest_action_sample, src=sending_worker, tag=1)
+    dist.recv(tensor=newest_prestate_sample, src=sending_worker, tag=2)
+    prestate_hash = hash(tuple(newest_prestate_sample.view(-1).tolist() +
+                               [newest_prev_tactic_sample.item()]))
+    eprint(f"Experience hash is {prestate_hash}")
+    newest_hashed_action_sample = torch.zeros(1, dtype=int)
+    dist.recv(tensor=newest_hashed_action_sample, src=sending_worker, tag=3)
+    newest_encoded_action_sample = torch.zeros(1, dtype=int)
+    dist.recv(tensor=newest_encoded_action_sample, src=sending_worker, tag=4)
     number_of_poststates = torch.zeros(1, dtype=int)
-    dist.recv(tensor=number_of_poststates, src=sending_worker, tag=2)
+    dist.recv(tensor=number_of_poststates, src=sending_worker, tag=5)
     post_states = []
     for _ in range(number_of_poststates.item()):
       newest_poststate_sample: torch.FloatTensor = \
         torch.zeros(self.encoding_size, dtype=torch.float32) #type: ignore
-      dist.recv(tensor=newest_poststate_sample, src=sending_worker, tag=3)
-      post_states.append(EObligation(newest_poststate_sample.to(device)))
-    self.replay_buffer.add_transition(
-      (EObligation(newest_prestate_sample.to(device)), int(newest_action_sample.item()),
-       post_states))
+      dist.recv(tensor=newest_poststate_sample, src=sending_worker, tag=6)
+      post_states.append(EObligation(newest_poststate_sample.to(device),
+                                     newest_encoded_action_sample.item()))
+    if self.ignore_after is not None and self.replay_buffer.buffer_steps >= self.ignore_after:
+        eprint("Ignoring a sample, but training anyway")
+    else:
+        from_obl = EObligation(newest_prestate_sample.to(device),
+                               newest_prev_tactic_sample.item())
+        eprint(f"From obl hash is {hash(from_obl)}")
+        self.replay_buffer.add_transition(
+          (from_obl,
+           int(newest_hashed_action_sample.item()),
+           post_states))
     self.replay_buffer.buffer_steps += 1
     self.signal_change.set()
 
   def receive_verification_sample(self, sending_worker: int) -> None:
     global vsample_changed
     device = "cuda"
+    newest_prev_tactic_sample = torch.zeros(1, dtype=int)
+    dist.recv(tensor=newest_prev_tactic_sample, src=sending_worker, tag=10)
     state_sample_buffer: torch.FloatTensor = \
       torch.zeros(self.encoding_size, dtype=torch.float32)  #type: ignore
-    dist.recv(tensor=state_sample_buffer, src=sending_worker, tag=5)
+    dist.recv(tensor=state_sample_buffer, src=sending_worker, tag=11)
     target_steps: torch.LongTensor = torch.zeros(1, dtype=int) #type: ignore
-    dist.recv(tensor=target_steps, src=sending_worker, tag=6)
-    state_sample = EObligation(state_sample_buffer.to(device))
+    dist.recv(tensor=target_steps, src=sending_worker, tag=12)
+    state_sample = EObligation(state_sample_buffer.to(device),
+                               newest_prev_tactic_sample.item())
     if state_sample in self.verification_states:
       assert target_steps.item() <= self.verification_states[state_sample], \
         "Got sent a target value  less than the previously expected value for this state!"
@@ -284,11 +307,16 @@ class BufferPopulatingThread(Thread):
 
   def receive_negative_sample(self, sending_worker: int) -> None:
     device = "cuda"
+    newest_prev_tactic_sample = torch.zeros(1, dtype=int)
+    dist.recv(tensor=newest_prev_tactic_sample, src=sending_worker, tag=20)
     state_sample_buffer: torch.FloatTensor = \
       torch.zeros(self.encoding_size, dtype=torch.float32) # type: ignore
-    dist.recv(tensor=state_sample_buffer, src=sending_worker, tag=7)
+    dist.recv(tensor=state_sample_buffer, src=sending_worker, tag=21)
+    state_hash = hash(tuple(state_sample_buffer.view(-1).tolist()))
+    eprint(f"negative sample hash is {state_hash}")
     self.replay_buffer.add_negative_sample(
-      EObligation(state_sample_buffer.to(device)))
+      EObligation(state_sample_buffer.to(device),
+                  newest_prev_tactic_sample.item()))
     self.replay_buffer.buffer_steps += 1
     self.signal_change.set()
 
@@ -331,11 +359,17 @@ class EncodedReplayBuffer:
       from_obl, action, _ = transition
       eprint(f"Adding positive transition from {hash(from_obl)}")
       to_obls = tuple(transition[2])
-      assert from_obl not in self._contents or len(self._contents[from_obl]) > 0
+      existing_entry = self._contents.get(from_obl, (0, set()))
+      assert from_obl not in self._contents or len(existing_entry[1]) > 0
+      for existing_action, existing_to_obls in existing_entry[1]:
+          assert action != existing_action or to_obls == existing_to_obls,\
+            f"From state {hash(from_obl)}, taking action has {action}, " \
+            f"resulted in obls {[hash(obl) for obl in to_obls]}, " \
+            "but in the past it resulted in obls " \
+            f"{[hash(obl) for obl in existing_to_obls]}."
       self._contents[from_obl] = \
         (self.window_end_position,
-         {(action, to_obls)} |
-         self._contents.get(from_obl, (0, set()))[1])
+         {(action, to_obls)} | existing_entry[1])
       self.window_end_position += 1
   def add_negative_sample(self, state: EObligation) -> None:
     with self.lock:
@@ -371,7 +405,9 @@ def print_vvalue_errors(gamma: float, vnetwork: nn.Module,
                         verification_samples: Dict[EObligation, int]):
   device = "cuda"
   items = list(verification_samples.items())
-  predicted_v_values = vnetwork(torch.cat([obl.contents.view(1, -1) for obl, _ in items], dim=0)).view(-1)
+  predicted_v_values = vnetwork(
+    torch.cat([obl.local_context.view(1, -1) for obl, _ in items], dim=0),
+    torch.LongTensor([obl.previous_tactic for obl, _ in items]).to(device)).view(-1)
   predicted_steps = torch.log(predicted_v_values) / math.log(gamma)
   target_steps: FloatTensor = torch.tensor([steps for _, steps in items]).to(device) #type: ignore
   step_errors = torch.abs(predicted_steps - target_steps)

--- a/src/gen_rl_tasks.py
+++ b/src/gen_rl_tasks.py
@@ -54,6 +54,8 @@ def add_args_to_parser(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("-p", "--num-predictions", default=16, type=int)
     parser.add_argument("json_project_file", type=Path)
 
+ProofSpec = Tuple[str, str, str, str]
+
 @dataclass(eq=True, unsafe_hash=True)
 class RLTask:
     project: str
@@ -90,7 +92,7 @@ class RLTask:
     @classmethod
     def from_job(cls, job: ReportJob) -> 'RLTask':
         return RLTask(job.project_dir, job.filename, job.module_prefix, job.lemma_statement, -1, -1, [], [])
-    def to_proof_spec(self) -> Tuple[str, str, str, str]:
+    def to_proof_spec(self) -> ProofSpec:
         return self.project, self.src_file, self.module_prefix, self.proof_statement
     @property
     def tactic_prefix(self) -> List[str]:

--- a/src/models/features_polyarg_predictor.py
+++ b/src/models/features_polyarg_predictor.py
@@ -57,8 +57,10 @@ from dataloader import (features_polyarg_tensors,
                         get_num_indices,
                         get_word_feature_vocab_sizes,
                         get_vec_features_size,
+                        get_prev_tactic_vocab_size,
                         DataloaderArgs,
-                        get_fpa_words)
+                        get_fpa_words,
+                        encode_prev_tactic)
 
 import coq_serapy
 
@@ -359,6 +361,13 @@ class FeaturesPolyargPredictor(
         #         assert batch_pred.prediction == single_pred.prediction, \
         #             (batch_pred, single_pred)
         return predictions
+
+    @property
+    def prev_tactic_vocab_size(self) -> int:
+        return get_prev_tactic_vocab_size(self.metadata)
+
+    def prev_tactic_stem_idx(self, prev_tactic: str) -> int:
+        return encode_prev_tactic(self.metadata, prev_tactic)
 
     def getAllPredictionIdxs(self, context: TacticContext,
                              blacklist: List[str]) -> List[Tuple[float, int, int]]:

--- a/src/multi_project_report.py
+++ b/src/multi_project_report.py
@@ -38,7 +38,7 @@ def multi_project_index(report_dir: str) -> None:
     write_html(report_dir, total_theorems, total_success, project_stats)
     base = Path(os.path.abspath(__file__)).parent.parent / "reports"
     for filename in extra_files:
-        shutil.copyfile(base / filename, report_dir / filename)
+        shutil.copyfile(base / filename, Path(report_dir) / filename)
 
 def get_stats(project_dir: str) -> Tuple[int, int]:
     with open(os.path.join(project_dir, "index.html")) as f:

--- a/src/rl.py
+++ b/src/rl.py
@@ -1322,6 +1322,18 @@ def randomly_order_by_scores(xs: List[T], scorer: Callable[[T], float]) -> List[
         del scores_left[next_el_idx]
     return result
 
+def prev_tactic_from_prefix(tactic_prefix: List[str]) -> str:
+    bracket_depth = 0
+    for tac in reversed(tactic_prefix):
+        if tac == "{":
+            if bracket_depth > 0:
+                bracket_depth -= 1
+        elif tac == "}":
+            bracket_depth += 1
+        elif bracket_depth == 0:
+            return tac
+    return "Proof"
+
 @dataclass
 class EObligation:
   local_context: torch.FloatTensor

--- a/src/rl.py
+++ b/src/rl.py
@@ -11,8 +11,10 @@ import math
 import pickle
 import sys
 from pathlib import Path
+from dataclasses import dataclass
 from typing import (List, Optional, Dict, Tuple, Union, Any, Set,
-                    Sequence, TypeVar, Callable, OrderedDict, Iterable)
+                    Sequence, TypeVar, Callable, OrderedDict, Iterable,
+                    Iterator)
 import warnings
 
 from util import unwrap, eprint, print_time, nostderr
@@ -23,6 +25,7 @@ with print_time("Importing torch"):
     import torch.nn.functional as F
     from torch import optim
     import torch.optim.lr_scheduler as scheduler
+    import torch.cuda
 
 #pylint: disable=wrong-import-order
 from tqdm import tqdm
@@ -41,6 +44,7 @@ with print_time("Importing search code"):
     from search_strategies import completed_proof
 
     from models.tactic_predictor import (TacticPredictor, Prediction)
+    from models.features_polyarg_predictor import FeaturesPolyargPredictor
 
 optimizers = {
   "RMSprop": optim.RMSprop,
@@ -100,6 +104,7 @@ def add_args_to_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentPars
     parser.add_argument("-w", "--window-size", default=2560)
     parser.add_argument("-p", "--num-predictions", default=5, type=int)
     parser.add_argument("--hidden-size", type=int, default=128)
+    parser.add_argument("--tactic-embedding-size", type=int, default=32)
     parser.add_argument("--num-layers", type=int, default=3)
     parser.add_argument("--batch-step", default=None, type=int)
     parser.add_argument("--lr-step", default=0.8, type=float)
@@ -301,14 +306,18 @@ class ReinforcementWorker:
         return success
 
     def check_vval_steps_task(self, task: RLTask) -> None:
-        file_worker = self._get_worker(task.src_file)
+        file_worker = self._get_worker(str(task.src_file))
+        assert file_worker.coq
         file_worker.run_into_task(task.to_job(), task.tactic_prefix)
-        check_vval_steps(self.args, file_worker.coq, self.predictor, self.v_network)
+        check_vval_steps(self.args, file_worker.coq,
+                         self.predictor, self.v_network)
 
 
-    def estimate_starting_vval(self, job: ReportJob, tactic_prefix: List[str],
+    def estimate_starting_vval(self,
+                               job: ReportJob, tactic_prefix: List[str],
                                restart: bool = True) -> float :
         file_worker = self._get_worker(job.filename)
+        assert file_worker.coq
         try:
             file_worker.run_into_task(job, tactic_prefix)
         except coq_serapy.CoqAnomaly:
@@ -320,8 +329,16 @@ class ReinforcementWorker:
             raise
 
         context: Optional[ProofContext] = file_worker.coq.proof_context
+        if len(tactic_prefix) > 0:
+            prev_tactic = tactic_prefix[-1]
+        else:
+            prev_tactic = "Proof."
         assert context is not None
-        all_obl_scores = self.v_network(context.fg_goals)
+        all_obl_scores = self.v_network(
+          context.fg_goals,
+          [prev_tactic]
+          * len(context.fg_goals))
+        assert len(context.fg_goals) == 1
 
         resulting_state_val = math.prod([s.item() for s in all_obl_scores])
 
@@ -350,6 +367,8 @@ def possibly_resume_rworker(args: argparse.Namespace) \
     # predictor = get_predictor(args)
     # predictor = DummyPredictor()
     predictor = MemoizingPredictor(get_predictor(args))
+    assert isinstance(predictor.underlying_predictor, FeaturesPolyargPredictor)
+    tactic_vocab_size = predictor.underlying_predictor.prev_tactic_vocab_size
     if args.resume == "ask" and args.output_file.exists():
         print(f"Found existing weights at {args.output_file}. Resume?")
         response = input("[Y/n] ")
@@ -365,7 +384,7 @@ def possibly_resume_rworker(args: argparse.Namespace) \
     else:
         resume = args.resume
 
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    device = "cuda" if torch.cuda.is_available() else "cpu"
     if resume == "yes":
         is_singlethreaded, replay_buffer, steps_already_done, network_state, \
           tnetwork_state, shorter_proofs_dict, random_state = \
@@ -375,13 +394,18 @@ def possibly_resume_rworker(args: argparse.Namespace) \
         print(f"Resuming from existing weights of {steps_already_done} steps")
         if args.start_from is not None:
             print("WARNING: Not starting from weights passed in --start-from because we're resuming from a partial run")
-        v_network = VNetwork(None, args.learning_rate,
+        v_network = VNetwork(None, predictor.underlying_predictor,
+                             args.learning_rate,
                              args.batch_step, args.lr_step,
-                             args.optimizer, args.hidden_size,
+                             args.optimizer, tactic_vocab_size,
+                             args.tactic_embedding_size,
+                             args.hidden_size,
                              args.num_layers)
-        target_network = VNetwork(None, args.learning_rate,
+        target_network = VNetwork(None, predictor.underlying_predictor,
+                                  args.learning_rate,
                                   args.batch_step, args.lr_step,
-                                  args.optimizer, args.hidden_size,
+                                  args.optimizer, tactic_vocab_size,
+                                  args.tactic_embedding_size, args.hidden_size,
                                   args.num_layers)
         v_network.load_state(network_state)
         target_network.load_state(tnetwork_state)
@@ -399,12 +423,19 @@ def possibly_resume_rworker(args: argparse.Namespace) \
         replay_buffer = None
         random_state = random.getstate()
         with print_time("Building models"):
-            v_network = VNetwork(args.coq2vec_weights, args.learning_rate,
+            v_network = VNetwork(args.coq2vec_weights,
+                                 predictor.underlying_predictor,
+                                 args.learning_rate,
                                  args.batch_step, args.lr_step, args.optimizer,
+                                 tactic_vocab_size, args.tactic_embedding_size,
                                  args.hidden_size, args.num_layers)
-            target_network = VNetwork(args.coq2vec_weights, args.learning_rate,
+            target_network = VNetwork(args.coq2vec_weights,
+                                      predictor.underlying_predictor,
+                                      args.learning_rate,
                                       args.batch_step, args.lr_step,
-                                      args.optimizer, args.hidden_size,
+                                      args.optimizer, tactic_vocab_size,
+                                      args.tactic_embedding_size,
+                                      args.hidden_size,
                                       args.num_layers)
             # This ensures that the target and obligation will share a cache for coq2vec encodings
             target_network.obligation_encoder = v_network.obligation_encoder
@@ -534,11 +565,43 @@ class CachedObligationEncoder(coq2vec.CoqContextVectorizer):
                 self.obl_cache.popitem(last=False)
         return encoded
 
+class VModel(nn.Module):
+    tactic_embedding: nn.Embedding
+    prediction_network: nn.Module
+    prev_tactic_vocab_size: int
+
+    def __init__(self, local_context_embedding_size: int,
+                 previous_tactic_vocab_size: int,
+                 previous_tactic_embedding_size: int,
+                 hidden_size: int,
+                 num_layers: int) -> None:
+        super().__init__()
+        self.tactic_embedding = nn.Embedding(previous_tactic_vocab_size,
+                                             previous_tactic_embedding_size)
+        layers: List[nn.Module] = [nn.Linear(local_context_embedding_size +
+                                   previous_tactic_embedding_size,
+                                   hidden_size)]
+        for layer_idx in range(num_layers - 1):
+            layers += [nn.ReLU(), nn.Linear(hidden_size, hidden_size)]
+        layers += [nn.ReLU(), nn.Linear(hidden_size, 1), nn.Sigmoid()]
+        self.prediction_network = nn.Sequential(*layers)
+        self.prev_tactic_vocab_size = previous_tactic_vocab_size
+        pass
+    def forward(self, local_context_embeddeds: torch.FloatTensor,
+                prev_tactic_indices: torch.LongTensor) -> torch.FloatTensor:
+        return self.prediction_network(torch.cat(
+            (local_context_embeddeds,
+             self.tactic_embedding(prev_tactic_indices)),
+            dim=1))
+
 class VNetwork:
-    obligation_encoder: Optional[coq2vec.CoqContextVectorizer]
-    network: Optional[nn.Module]
+    obligation_encoder: Optional[CachedObligationEncoder]
+    predictor: FeaturesPolyargPredictor
+    network: Optional[VModel]
     steps_trained: int
     optimizer: optim.Optimizer
+    adjuster: scheduler.LRScheduler
+    device: str
     batch_step: int
     lr_step: int
     learning_rate: float
@@ -554,6 +617,8 @@ class VNetwork:
                 self.hidden_size, self.num_layers)
 
     def _load_encoder_state(self, encoder_state: Any,
+                            previous_tactic_vocab_size: int,
+                            previous_tactic_embedding_size: int,
                             hidden_size: int,
                             num_layers: int) -> None:
         term_encoder = coq2vec.CoqTermRNNVectorizer()
@@ -561,46 +626,43 @@ class VNetwork:
         num_hyps = 5
         assert self.obligation_encoder is None, "Can't load weights twice!"
         self.obligation_encoder = CachedObligationEncoder(term_encoder, num_hyps)
-        insize = term_encoder.hidden_size * (num_hyps + 1)
+        local_context_embedding_size = \
+          term_encoder.hidden_size * (num_hyps + 1)
         self.hidden_size = hidden_size
         self.num_layers = num_layers
-        self.network = model_setup(insize, hidden_size, num_layers)
+        self.network = VModel(local_context_embedding_size,
+                              previous_tactic_vocab_size,
+                              previous_tactic_embedding_size,
+                              hidden_size, num_layers)
         self.network.to(self.device)
         self.optimizer: optim.Optimizer = optimizers[self.optimizer_type](self.network.parameters(),
                                                                      lr=self.learning_rate)
         self.adjuster = scheduler.StepLR(self.optimizer, self.batch_step,
                                          self.lr_step)
+        self.tactic_vocab_size: int = previous_tactic_vocab_size
 
-    def load_state(self, state: Any, hidden_size: Optional[int] = None,
-                   num_layers: Optional[int] = None) -> None:
-        if len(state) == 3:
-            assert hidden_size is not None
-            assert num_layers is not None
-            network_state, encoder_state, obl_cache = state
-            self._load_encoder_state(encoder_state, hidden_size, num_layers)
-            assert self.obligation_encoder
-            network_state, encoder_state = state
-            self._load_encoder_state(encoder_state, hidden_size, num_layers)
-        else:
-            assert len(state) == 5
-            network_state, encoder_state, obl_cache, \
-              loaded_hidden_size, loaded_num_layers = state
-            if hidden_size is not None or num_layers is not None:
-                eprint("Warning: Ignoring --hidden-size and --num-layers arguments "
-                       "because we're loading an existing network.")
-            self._load_encoder_state(encoder_state, loaded_hidden_size,
-                                     loaded_num_layers)
-            assert self.obligation_encoder
-            self.obligation_encoder.obl_cache = obl_cache
+    def load_state(self, state: Any) -> None:
+        assert len(state) == 4
+        network_state, encoder_state, obl_cache, training_args = state
+        self._load_encoder_state(encoder_state,
+                                 self.tactic_vocab_size,
+                                 training_args.tactic_embedding_size,
+                                 training_args.hidden_size,
+                                 training_args.num_layers)
+        assert self.obligation_encoder
+        self.obligation_encoder.obl_cache = obl_cache
         assert self.network
         self.network.load_state_dict(network_state)
         self.network.to(self.device)
 
 
-    def __init__(self, coq2vec_weights: Optional[Path], learning_rate: float,
+    def __init__(self, coq2vec_weights: Optional[Path],
+                 predictor: FeaturesPolyargPredictor,
+                 learning_rate: float,
                  batch_step: int, lr_step: int, optimizer_type: str,
+                 tactic_vocab_size: int, tactic_embedding_size: int,
                  hidden_size: int, num_layers: int) -> None:
-        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        self.device = "cuda" if torch.cuda.is_available() else "cpu"
         self.batch_step = batch_step
         self.lr_step = lr_step
         self.learning_rate = learning_rate
@@ -610,34 +672,70 @@ class VNetwork:
         # Steps trained only counts from the last resume! Don't use
         # for anything more essential than printing.
         self.steps_trained = 0
-        self.total_loss = torch.tensor(0.0).to(self.device)
+        self.total_loss = torch.FloatTensor([0.0]).to(self.device)
+        self.predictor = predictor
         if coq2vec_weights is not None:
-            self._load_encoder_state(torch.load(str(coq2vec_weights), map_location=self.device), hidden_size, num_layers)
+            self._load_encoder_state(torch.load(str(coq2vec_weights),
+                                                map_location=self.device),
+                                     tactic_vocab_size,
+                                     tactic_embedding_size,
+                                     hidden_size, num_layers)
 
-    def __call__(self, obls: Union[Obligation, List[Obligation]]) -> torch.FloatTensor:
+    def __call__(self, obls: Union[Obligation, List[Obligation]],
+                 prev_tactics: Union[str, List[str]]) -> torch.FloatTensor:
         assert self.obligation_encoder, \
             "No loaded encoder! Pass encoder weights to __init__ or call set_state()"
         assert self.network
         if isinstance(obls, Obligation):
+            assert isinstance(prev_tactics, int)
             obls = [obls]
+            prev_tactics = [prev_tactics]
         else:
             assert isinstance(obls, list)
+            assert isinstance(prev_tactics, list)
             if len(obls) == 0:
-                return torch.tensor([])
+                return torch.FloatTensor([])
 
         encoded = self.obligation_encoder.\
             obligations_to_vectors_cached(obls)
-        scores = self.network(encoded).view(len(obls))
+        encoded_prev_tactics = torch.LongTensor([
+          self.predictor.prev_tactic_stem_idx(prev_tactic)
+          for prev_tactic in prev_tactics])
+        scores = self.network(encoded, encoded_prev_tactics).view(len(obls))
+        return scores
+    def call_encoded(self, obls: Union[Obligation, List[Obligation]],
+                     encoded_prev_tactics: Union[int, List[int]]) \
+          -> torch.FloatTensor:
+        assert self.obligation_encoder, \
+            "No loaded encoder! Pass encoder weights to __init__ or call set_state()"
+        assert self.network
+        if isinstance(obls, Obligation):
+            assert isinstance(encoded_prev_tactics, int)
+            obls = [obls]
+            prev_tactics = [encoded_prev_tactics]
+        else:
+            assert isinstance(obls, list)
+            assert isinstance(encoded_prev_tactics, list)
+            if len(obls) == 0:
+                return torch.FloatTensor([])
+
+        encoded = self.obligation_encoder.\
+            obligations_to_vectors_cached(obls)
+        scores = self.network(encoded, encoded_prev_tactics).view(len(obls))
         return scores
 
-    def train(self, inputs: List[Obligation],
+    def train(self, inputs: List[Tuple[int, Obligation]],
               target_outputs: List[float],
               verbosity: int = 0) -> float:
         del verbosity
         assert self.obligation_encoder, \
             "No loaded encoder! Pass encoder weights to __init__ or call set_state()"
         # with print_time("Training", guard=verbosity >= 1):
-        actual = self(inputs)
+        input_contexts = [input_context for prev_tactic, input_context in
+                          inputs]
+        input_prev_tactics = [prev_tactic
+                              for prev_tactic, input_context in inputs]
+        actual = self.call_encoded(input_contexts, input_prev_tactics)
         target = torch.FloatTensor(target_outputs).to(self.device)
         loss = F.mse_loss(actual, target)
         self.optimizer.zero_grad()
@@ -656,13 +754,14 @@ def experience_proof(args: argparse.Namespace,
                      v_network: VNetwork,
                      replay_buffer: 'ReplayBuffer',
                      epsilon: float) -> Optional[int]:
-    path: List[ProofContext] = [coq.proof_context]
-    initial_open_obligations = len(coq.proof_context.all_goals)
+    assert coq.proof_context
+    path: List[ProofContext] = [unwrap(coq.proof_context)]
+    initial_open_obligations = len(unwrap(coq.proof_context).all_goals)
     trace: List[str] = []
     for step in range(args.steps_per_episode):
         before_obl = unwrap(coq.proof_context).fg_goals[0]
         if args.verbose >= 3:
-            coq_serapy.summarizeContext(coq.proof_context)
+            coq_serapy.summarizeContext(unwrap(coq.proof_context))
         actions = predictor.predictKTactics(
             truncate_tactic_context(FullContext(coq.local_lemmas[:-1],
                                                 coq.prev_tactics,
@@ -674,6 +773,7 @@ def experience_proof(args: argparse.Namespace,
                guard=args.verbose >= 3)
         if random.random() < epsilon:
             eprint("Using best-scoring action", guard=args.verbose >= 3)
+            assert isinstance(predictor, FeaturesPolyargPredictor)
             action_scores = evaluate_actions(
                 coq, v_network, path,
                 [action.prediction for action in actions])
@@ -692,8 +792,10 @@ def experience_proof(args: argparse.Namespace,
                 try:
                     coq.run_stmt(action.prediction)
                     resulting_context = coq.proof_context
+                    assert resulting_context is not None
                     coq.cancel_last_noupdate()
-                    if any(coq_serapy.contextSurjective(resulting_context, path_context)
+                    if any(coq_serapy.contextSurjective(resulting_context,
+                                                        path_context)
                            for path_context in path):
                         continue
                     chosen_action = action
@@ -707,15 +809,19 @@ def experience_proof(args: argparse.Namespace,
                     pass
             if chosen_action is None:
                 break
+        assert chosen_action is not None
         resulting_obls = execute_action(coq, chosen_action.prediction)
         trace.append(chosen_action.prediction)
 
         eprint(f"Taking action {chosen_action}",
                guard=args.verbose >= 2)
 
+        assert coq.proof_context is not None
         if args.verbose >= 3:
             coq_serapy.summarizeContext(coq.proof_context)
-        replay_buffer.add_transition((before_obl, chosen_action.prediction, resulting_obls))
+        replay_buffer.add_transition((coq.prev_tactics[-1], before_obl,
+                                      chosen_action.prediction,
+                                      set(resulting_obls)))
         path.append(coq.proof_context)
 
         current_open_obligations = len(coq.proof_context.all_goals)
@@ -727,13 +833,18 @@ def experience_proof(args: argparse.Namespace,
 def evaluate_actions(coq: coq_serapy.CoqAgent,
                      v_network: VNetwork, path: List[ProofContext],
                      actions: List[str], verbosity: int = 0) -> List[float]:
+    assert isinstance(actions[0], str)
     resulting_contexts: List[Optional[ProofContext]] = \
         [action_result(coq, path, action, verbosity) for action in actions]
     num_output_obls: List[Optional[int]] = [len(context.fg_goals) if context else None
                                             for context in resulting_contexts]
     all_obls = [obl for context in resulting_contexts
                 for obl in (context.fg_goals if context else [])]
-    all_obl_scores = v_network(all_obls)
+    all_prev_tactics = \
+      [prev_tac for prev_tac, num_obls in
+       zip(actions, num_output_obls)
+       for _ in (range(num_obls) if num_obls is not None else [])]
+    all_obl_scores = v_network(all_obls, all_prev_tactics)
     resulting_action_scores = []
     cur_obl_idx = 0
     for num_obls in num_output_obls:
@@ -747,6 +858,7 @@ def evaluate_actions(coq: coq_serapy.CoqAgent,
 
 def action_result(coq: coq_serapy.CoqAgent, path: List[ProofContext],
                   action: str, verbosity: int = 0) -> Optional[ProofContext]:
+    assert isinstance(action, str)
     try:
         coq.run_stmt(action)
     except (coq_serapy.CoqTimeoutError, coq_serapy.ParseError,
@@ -756,7 +868,7 @@ def action_result(coq: coq_serapy.CoqAgent, path: List[ProofContext],
             coq_serapy.UnrecognizedError) as e:
         eprint(f"Action produced error {e}", guard=verbosity >= 3)
         return None
-    context_after = coq.proof_context
+    context_after = unwrap(coq.proof_context)
     coq.cancel_last_noupdate()
     if any(coq_serapy.contextSurjective(context_after, path_context)
            for path_context in path):
@@ -764,9 +876,11 @@ def action_result(coq: coq_serapy.CoqAgent, path: List[ProofContext],
     return context_after
 
 def execute_action_trace(coq: coq_serapy.CoqAgent,
-                         action: str) -> List[str]:
+                         action: str) -> \
+      List[Union[Tuple[str, ProofContext], str]]:
     coq.run_stmt(action)
-    trace = [action]
+    trace: List[Union[Tuple[str, ProofContext], str]]  = \
+      [action]
 
     subgoals_closed = 0
     if len(unwrap(coq.proof_context).fg_goals) == 0 and \
@@ -802,7 +916,7 @@ def execute_action(coq: coq_serapy.CoqAgent,
        (coq.count_fg_goals() > 0 and subgoals_closed > 0):
         coq.run_stmt("{")
 
-    assert len(coq.proof_context.all_goals) == 0 or len(coq.proof_context.fg_goals) > 0
+    assert len(unwrap(coq.proof_context).all_goals) == 0 or len(unwrap(coq.proof_context).fg_goals) > 0
 
     return resulting_obls
 
@@ -810,20 +924,29 @@ def train_v_network(args: argparse.Namespace,
                     v_network: VNetwork,
                     target_network: VNetwork,
                     replay_buffer: 'ReplayBuffer'):
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    device = "cuda" if torch.cuda.is_available() else "cpu"
     samples = replay_buffer.sample(args.batch_size)
     if samples is None:
         return
-    inputs = [start_obl for start_obl, action_records in samples]
+    inputs = [(prev_tactic, start_obl)
+              for (prev_tactic, start_obl), action_records
+              in samples]
     num_resulting_obls = [[len(resulting_obls)
                            for action, resulting_obls in action_records]
                           for starting_obl, action_records in samples]
-    all_obls = [obl
-                for starting_obl, action_records in samples
-                for action, resulting_obls in action_records
-                for obl in resulting_obls]
+    all_resulting_contexts  = \
+      [obl
+       for (prev_tactic, starting_obl) , action_records in samples
+       for action, resulting_obls in action_records
+       for obl in resulting_obls]
+    all_resulting_prev_tactics = [
+      action
+      for _, action_records in samples
+      for action, resulting_obls in action_records
+      for obl in resulting_obls]
     with torch.no_grad():
-        all_obl_scores = target_network(all_obls)
+        all_obl_scores = target_network(all_resulting_contexts,
+                                        all_resulting_prev_tactics)
     outputs = []
     cur_row = 0
     for resulting_obl_lens in num_resulting_obls:
@@ -838,7 +961,7 @@ def train_v_network(args: argparse.Namespace,
     v_network.train(inputs, outputs, verbosity=args.verbose)
     if args.print_loss_every and (v_network.steps_trained + 1) % args.print_loss_every == 0:
         avg_loss = v_network.total_loss / args.print_loss_every
-        v_network.total_loss = torch.tensor(0.0).to(device)
+        v_network.total_loss = torch.FloatTensor([0.0]).to(device)
         print(f"Loss: {avg_loss}; Learning rate: {v_network.optimizer.param_groups[0]['lr']}")
 
 class MemoizingPredictor(TacticPredictor):
@@ -900,7 +1023,7 @@ def save_state(args: argparse.Namespace, worker: ReinforcementWorker,
                     shorter_proofs_dict,
                     random.getstate()), f)
 
-def path_obl_length(path: List[Union[ProofContext, str]]) -> int:
+def path_obl_length(path: List[Union[Tuple[str, ProofContext], str]]) -> int:
     bracket_depth = 0
     cur_length = 0
     for context_or_bracket in path:
@@ -918,13 +1041,15 @@ def path_obl_length(path: List[Union[ProofContext, str]]) -> int:
 
 def print_path_vval_errors(args: argparse.Namespace,
                            v_network: VNetwork,
-                           path: List[Union[ProofContext, str]]) -> None:
-    for step_idx, context in enumerate(path):
-        if isinstance(context, str):
+                           path: List[Union[Tuple[str, ProofContext], str]]) \
+      -> None:
+    for step_idx, path_item in enumerate(path):
+        if isinstance(path_item, str):
             continue
+        prev_tactic, context = path_item
         target_steps = path_obl_length(path[step_idx:])
         assert len(context.fg_goals) == 1, len(context.fg_goals)
-        vval_predicted = v_network(context.fg_goals[0])
+        vval_predicted = v_network(context.fg_goals[0], prev_tactic)
         steps_predicted = math.log(max(sys.float_info.min, vval_predicted.item())) \
             / math.log(args.gamma)
         print(f"At obligation: {coq_serapy.summarizeObligation(context.fg_goals[0])}")
@@ -937,9 +1062,10 @@ def check_vval_steps(args: argparse.Namespace,
                      coq: coq_serapy.CoqAgent,
                      predictor: TacticPredictor,
                      v_network: VNetwork) -> None:
-    path: List[Union[ProofContext, str]] = [coq.proof_context]
-    trace = list(path)
-    initial_open_obligations = len(coq.proof_context.all_goals)
+    path: List[ProofContext] = [unwrap(coq.proof_context)]
+    trace: List[Union[Tuple[str, ProofContext], str]] = \
+        [(coq.prev_tactics[-1], unwrap(coq.proof_context))]
+    initial_open_obligations = len(unwrap(coq.proof_context).all_goals)
     for _step in range(args.steps_per_episode):
         actions = predictor.predictKTactics(
             truncate_tactic_context(FullContext(
@@ -949,6 +1075,7 @@ def check_vval_steps(args: argparse.Namespace,
                                     30),
             args.num_predictions,
             blacklist=args.blacklisted_tactics)
+        assert isinstance(predictor, FeaturesPolyargPredictor)
         action_scores = evaluate_actions(coq, v_network, path,
                                          [action.prediction for action in actions],
                                          args.verbose)
@@ -956,21 +1083,21 @@ def check_vval_steps(args: argparse.Namespace,
         if best_score == -float("Inf"):
             break
         action_trace = execute_action_trace(coq, best_action.prediction)
-        current_open_obligations = len(coq.proof_context.all_goals)
+        current_open_obligations = len(unwrap(coq.proof_context).all_goals)
         if current_open_obligations < initial_open_obligations:
             break
         trace += action_trace
-        trace.append(coq.proof_context)
-        path.append(coq.proof_context)
+        trace.append((best_action.prediction, unwrap(coq.proof_context)))
+        path.append(unwrap(coq.proof_context))
     print_path_vval_errors(args, v_network, trace)
 
 def evaluate_proof(args: argparse.Namespace,
                    coq: coq_serapy.CoqAgent,
                    predictor: TacticPredictor,
                    v_network: VNetwork) -> bool:
-    path: List[ProofContext] = [coq.proof_context]
+    path: List[ProofContext] = [unwrap(coq.proof_context)]
     proof_succeeded = False
-    initial_open_obligations = len(coq.proof_context.all_goals)
+    initial_open_obligations = len(unwrap(coq.proof_context).all_goals)
     for _step in range(args.steps_per_episode):
         actions = predictor.predictKTactics(
             truncate_tactic_context(FullContext(
@@ -981,7 +1108,7 @@ def evaluate_proof(args: argparse.Namespace,
             args.num_predictions,
             blacklist=args.blacklisted_tactics)
         if args.verbose >= 1:
-            coq_serapy.summarizeContext(coq.proof_context)
+            coq_serapy.summarizeContext(unwrap(coq.proof_context))
         eprint(f"Trying predictions {[action.prediction for action in actions]}",
                guard=args.verbose >= 2)
         if args.evaluate_baseline :
@@ -990,7 +1117,8 @@ def evaluate_proof(args: argparse.Namespace,
                 if action_result(coq, path, action.prediction, args.verbose) :
                     best_action, best_score = action, action.certainty
                     break
-        else :
+        else:
+            assert isinstance(predictor, FeaturesPolyargPredictor)
             action_scores = evaluate_actions(coq, v_network, path,
                                              [action.prediction for action in actions],
                                              args.verbose)
@@ -1001,8 +1129,8 @@ def evaluate_proof(args: argparse.Namespace,
         eprint(f"Taking action {best_action} with estimated value {best_score}",
                guard=args.verbose >= 1)
         execute_action(coq, best_action.prediction)
-        path.append(coq.proof_context)
-        current_open_obligations = len(coq.proof_context.all_goals)
+        path.append(unwrap(coq.proof_context))
+        current_open_obligations = len(unwrap(coq.proof_context).all_goals)
         if current_open_obligations < initial_open_obligations:
             proof_succeeded = True
             break
@@ -1053,7 +1181,12 @@ def verify_vvals(args: argparse.Namespace,
             eprint(f"Skipping job {task} with prefix {task.tactic_prefix} because it can't purely focused")
             jobs_skipped += 1
             continue
-        vval_predicted = worker.estimate_starting_vval(task.to_job(), task.tactic_prefix)
+        assert isinstance(worker.predictor, MemoizingPredictor)
+        assert isinstance(worker.predictor.underlying_predictor,
+                          FeaturesPolyargPredictor)
+        vval_predicted = worker.estimate_starting_vval(
+            task.to_job(),
+            task.tactic_prefix)
         steps_predicted = math.log(max(sys.float_info.min, vval_predicted)) / math.log(args.gamma)
         eprint(f"Predicted vval {vval_predicted} ({steps_predicted} steps) vs "
                f"{target_steps} actual steps", guard=args.verbose >= 1)
@@ -1073,11 +1206,11 @@ def stringified_percent(total : float, outof : float) -> str:
         return "NaN"
     return f"{(total * 100 / outof):10.2f}"
 
-Transition = Tuple[str, Sequence[Obligation]]
-FullTransition = Tuple[Obligation, str, List[Obligation]]
+Transition = Tuple[str, Set[Obligation]]
+FullTransition = Tuple[int, Obligation, str, Set[Obligation]]
 
 class ReplayBuffer:
-    _contents: Dict[Obligation, Tuple[int, Set[Transition]]]
+    _contents: Dict[Tuple[int, Obligation], Tuple[int, Set[Transition]]]
     window_size: int
     window_end_position: int
     allow_partial_batches: bool
@@ -1088,8 +1221,8 @@ class ReplayBuffer:
         self.allow_partial_batches = allow_partial_batches
         self._contents = {}
 
-    def sample(self, batch_size) -> Optional[List[Tuple[Obligation, Set[Transition]]]]:
-        sample_pool: List[Tuple[Obligation, List[Transition]]] = []
+    def sample(self, batch_size) -> Optional[List[Tuple[Tuple[int, Obligation], Set[Transition]]]]:
+        sample_pool: List[Tuple[Tuple[int, Obligation], Set[Transition]]] = []
         for obl, (last_updated, transitions) in self._contents.copy().items():
             if last_updated <= self.window_end_position - self.window_size:
                 del self._contents[obl]
@@ -1102,18 +1235,19 @@ class ReplayBuffer:
         return None
 
     def add_transition(self, transition: FullTransition) -> None:
-        from_obl = transition[0]
-        action = transition[1]
-        to_obls = tuple(transition[2])
-        self._contents[from_obl] = \
+        prev_tactic = transition[0]
+        from_obl = transition[1]
+        action = transition[2]
+        to_obls = set(transition[3])
+        self._contents[(prev_tactic, from_obl)] = \
             (self.window_end_position,
              {(action, to_obls)} |
-             self._contents.get(from_obl, (0, set()))[1])
+             self._contents.get((prev_tactic, from_obl), (0, set()))[1])
         self.window_end_position += 1
 
 # NOT THREAD SAFE
 @contextlib.contextmanager
-def log_time(msg: str) -> Iterable[None]:
+def log_time(msg: str) -> Iterator[None]:
     start = time.time()
     try:
         yield
@@ -1140,11 +1274,11 @@ def run_network_with_cache(f: Callable[[List[T]], torch.FloatTensor],
                            cached_outputs: List[Optional[torch.FloatTensor]]) \
                            -> torch.FloatTensor:
     assert len(values) == len(cached_outputs)
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    device = "cuda" if torch.cuda.is_available() else "cpu"
     output_list: List[Optional[torch.FloatTensor]] = list(cached_outputs)
     uncached_values: List[T] = []
     uncached_value_indices: List[int] = []
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    device = "cuda" if torch.cuda.is_available() else "cpu"
     for i, value in enumerate(values):
         if output_list[i] is None:
             uncached_values.append(value)
@@ -1154,7 +1288,7 @@ def run_network_with_cache(f: Callable[[List[T]], torch.FloatTensor],
         for idx, result in zip(uncached_value_indices, new_results):
             output_list[idx] = result
     
-    return torch.cat([t.unsqueeze(0) for t in output_list], dim=0)
+    return torch.cat([unwrap(t).unsqueeze(0) for t in output_list], dim=0)
 
 def tactic_prefix_is_usable(tactic_prefix: List[str]):
     for tactic in tactic_prefix:
@@ -1163,14 +1297,6 @@ def tactic_prefix_is_usable(tactic_prefix: List[str]):
             warnings.warn("Warning: Tactic has banned prefix. This should have had been filtered out during gen_rl_task")
             return False
     return True
-
-def model_setup(insize: int, hidden_size: int,
-                num_layers: int) -> nn.Module:
-    layers = [nn.Linear(insize, hidden_size)]
-    for layer_idx in range(num_layers - 1):
-        layers += [nn.ReLU(), nn.Linear(hidden_size, hidden_size)]
-    layers += [nn.ReLU(), nn.Linear(hidden_size, 1), nn.Sigmoid()]
-    return nn.Sequential(*layers)
 
 def sample_distribution(distribution: List[float]) -> int:
     rval = random.random()
@@ -1195,6 +1321,20 @@ def randomly_order_by_scores(xs: List[T], scorer: Callable[[T], float]) -> List[
         del xs_left[next_el_idx]
         del scores_left[next_el_idx]
     return result
+
+@dataclass
+class EObligation:
+  local_context: torch.FloatTensor
+  previous_tactic: int
+  def __hash__(self) -> int:
+    return hash(tuple(self.local_context.view(-1).tolist() +
+                      [self.previous_tactic]))
+  def __eq__(self, other: object) -> bool:
+    if not isinstance(other, EObligation):
+      return False
+    return bool(torch.all(self.local_context == other.local_context)) \
+             and self.previous_tactic == other.previous_tactic
+
 
 if __name__ == "__main__":
     main()

--- a/src/search_worker.py
+++ b/src/search_worker.py
@@ -283,7 +283,18 @@ class Worker:
                coq_serapy.kill_comments(job_lemma).strip() and \
               self.coq.sm_prefix == job_module:
                 return
-            self.skip_proof(careful)
+            try:
+                self.skip_proof(careful)
+            except coq_serapy.CoqAnomaly:
+                if restart_anomaly:
+                    self.restart_coq()
+                    self.reset_file_state()
+                    self.enter_file(job_file)
+                    eprint("Hit a coq anomaly! Restarting...",
+                           guard=self.args.verbose >= 1)
+                    self.run_into_job(job, False, careful)
+                    return
+                assert False
 
     def skip_proof(self, careful: bool) -> None:
         assert self.coq

--- a/src/supervised_v_values.py
+++ b/src/supervised_v_values.py
@@ -20,7 +20,8 @@ from ray.tune.search.optuna import OptunaSearch
 import coq2vec
 from coq_serapy import Obligation
 
-from rl import VNetwork, optimizers, FileReinforcementWorker
+from rl import (VNetwork, optimizers, FileReinforcementWorker,
+                VModel, prev_tactic_from_prefix)
 from gen_rl_tasks import RLTask
 from util import timeSince, print_time
 


### PR DESCRIPTION
A few features in this pull request: 
* First, the addition of negative examples, where a state in which all predicted tactics fail gets assigned a v value of 0 during training, instead of being excluded from training.
* Second, obligation state was augmented to include the previous tactic as a feature, since the predictor uses that, and it can break the markov-ness of the states if you don't (two states that look the same don't behave the same). There are still other instances of clashing states, but they are rarer.
* Third, a lot of code was added to track clashing states. When the same encoded state with the same action is producing a different set of obligations, we will now print a warning and ignore the new transition (instead of overwriting).